### PR TITLE
Synaptor PR part 2/3: new dags

### DIFF
--- a/dags/synaptor_dags.py
+++ b/dags/synaptor_dags.py
@@ -1,0 +1,111 @@
+"""DAG definition for synaptor workflows."""
+from datetime import datetime
+from configparser import ConfigParser
+
+from airflow import DAG
+from airflow.models import Variable
+
+from helper_ops import scale_up_cluster_op, scale_down_cluster_op
+from param_default import default_synaptor_param
+from synaptor_ops import manager_op, drain_op
+from synaptor_ops import synaptor_op, wait_op, generate_op
+
+
+# Processing parameters
+# We need to set a default so any airflow container can parse the dag before we
+# pass in a configuration file
+
+try:
+    param = Variable.get("synaptor_param", default_synaptor_param)
+    cp = ConfigParser()
+    cp.read_string(param)
+    MAX_CLUSTER_SIZE = cp.getint("Workflow", "maxclustersize")
+
+except:  # not sure why this doesn't work sometimes
+    MAX_CLUSTER_SIZE = 1
+
+
+default_args = {
+    "owner": "seuronbot",
+    "depends_on_past": False,
+    "start_date": datetime(2022, 2, 22),
+    "catchup": False,
+    "retries": 0,
+}
+
+# =========================================
+# Sanity check DAG
+# "update synaptor params"
+
+dag_sanity = DAG(
+    "synaptor_sanity_check",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=["synaptor"],
+)
+
+manager_op(dag_sanity, "sanity_check")
+
+
+# =========================================
+# File segmentation
+# "run synaptor file segmentation"
+
+fileseg_dag = DAG(
+    "synaptor_file_seg",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=["synaptor"],
+)
+
+
+# OP INSTANTIATION
+# Cluster management
+drain = drain_op(fileseg_dag)
+sanity_check = manager_op(fileseg_dag, "sanity_check")
+init_cloudvols = manager_op(fileseg_dag, "init_cloudvols")
+
+scale_up_cluster = scale_up_cluster_op(
+    fileseg_dag, "synaptor", "synaptor-cpu", 1, MAX_CLUSTER_SIZE, "cluster"
+)
+scale_down_cluster = scale_down_cluster_op(
+    fileseg_dag, "synaptor", "synaptor-cpu", 0, "cluster"
+)
+
+generate_self_destruct = generate_op(fileseg_dag, "self_destruct")
+wait_self_destruct = wait_op(fileseg_dag, "self_destruct")
+
+
+# Ops that do actual work
+workers = [synaptor_op(fileseg_dag, i) for i in range(MAX_CLUSTER_SIZE)]
+
+generate_chunk_ccs = generate_op(fileseg_dag, "chunk_ccs")
+wait_chunk_ccs = wait_op(fileseg_dag, "chunk_ccs")
+
+generate_merge_ccs = generate_op(fileseg_dag, "merge_ccs")
+wait_merge_ccs = wait_op(fileseg_dag, "merge_ccs")
+
+generate_remap = generate_op(fileseg_dag, "remap")
+wait_remap = wait_op(fileseg_dag, "remap")
+
+
+# DEPENDENCIES
+# Drain old tasks before doing anything
+drain >> sanity_check >> init_cloudvols  # >> generate_ngl_link
+
+# Worker dag
+(init_cloudvols >> scale_up_cluster >> workers >> scale_down_cluster)
+
+# Generator/task dag
+(
+    init_cloudvols
+    # >> sanity_check_report
+    >> generate_chunk_ccs
+    >> wait_chunk_ccs
+    >> generate_merge_ccs
+    >> wait_merge_ccs
+    >> generate_remap
+    >> wait_remap
+    >> generate_self_destruct
+    >> wait_self_destruct
+)

--- a/dags/synaptor_dags.py
+++ b/dags/synaptor_dags.py
@@ -109,3 +109,243 @@ drain >> sanity_check >> init_cloudvols  # >> generate_ngl_link
     >> generate_self_destruct
     >> wait_self_destruct
 )
+
+
+# =========================================
+# DB segmentation
+# "run synaptor db segmentation"
+#
+# This performs the "merge_ccs" task above in separate extra steps (in parallel)
+#
+# I will also soon add some database management commands (creating indexes)
+
+dbseg_dag = DAG(
+    "synaptor_db_seg",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=["synaptor"],
+)
+
+
+# OP INSTANTIATION
+# Cluster management
+drain = drain_op(dbseg_dag)
+sanity_check = manager_op(dbseg_dag, "sanity_check")
+init_cloudvols = manager_op(dbseg_dag, "init_cloudvols")
+init_db = manager_op(dbseg_dag, "init_db")
+
+scale_up_cluster = scale_up_cluster_op(
+    dbseg_dag, "synaptor", "synaptor-cpu", 1, MAX_CLUSTER_SIZE, "cluster"
+)
+scale_down_cluster = scale_down_cluster_op(
+    dbseg_dag, "synaptor", "synaptor-cpu", 0, "cluster"
+)
+
+generate_self_destruct = generate_op(dbseg_dag, "self_destruct")
+wait_self_destruct = wait_op(dbseg_dag, "self_destruct")
+
+
+# Ops that do actual work
+workers = [synaptor_op(dbseg_dag, i) for i in range(MAX_CLUSTER_SIZE)]
+
+generate_chunk_ccs = generate_op(dbseg_dag, "chunk_ccs")
+wait_chunk_ccs = wait_op(dbseg_dag, "chunk_ccs")
+
+generate_match_contins = generate_op(dbseg_dag, "match_contins")
+wait_match_contins = wait_op(dbseg_dag, "match_contins")
+
+generate_seg_graph_ccs = generate_op(dbseg_dag, "seg_graph_ccs")
+wait_seg_graph_ccs = wait_op(dbseg_dag, "seg_graph_ccs")
+
+generate_chunk_seg_map = generate_op(dbseg_dag, "chunk_seg_map")
+wait_chunk_seg_map = wait_op(dbseg_dag, "chunk_seg_map")
+
+generate_merge_seginfo = generate_op(dbseg_dag, "merge_seginfo")
+wait_merge_seginfo = wait_op(dbseg_dag, "merge_seginfo")
+
+generate_remap = generate_op(dbseg_dag, "remap")
+wait_remap = wait_op(dbseg_dag, "remap")
+
+
+# DEPENDENCIES
+# Drain old tasks before doing anything
+drain >> sanity_check >> init_cloudvols >> init_db  # >> generate_ngl_link
+
+# Worker dag
+(init_db >> scale_up_cluster >> workers >> scale_down_cluster)
+
+# Generator/task dag
+(
+    init_db
+    # >> sanity_check_report
+    >> generate_chunk_ccs
+    >> wait_chunk_ccs
+    >> generate_match_contins
+    >> wait_match_contins
+    >> generate_seg_graph_ccs
+    >> wait_seg_graph_ccs
+    >> generate_chunk_seg_map
+    >> wait_chunk_seg_map
+    >> generate_merge_seginfo
+    >> wait_merge_seginfo
+    >> generate_remap
+    >> wait_remap
+    >> generate_self_destruct
+    >> wait_self_destruct
+)
+
+
+# =========================================
+# DB assignment
+# "run synaptor assignment"
+#
+# This adds three more parallel processing stages for synapse assignment
+#
+# The "chunk_edges" steps requires a GPU, so we need to add some extra
+# operators to scale CPU/GPU nodes up and down in waves.
+#
+# I will also soon add some database management commands (creating indexes)
+
+assign_dag = DAG(
+    "synaptor_assignment",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=["synaptor"],
+)
+
+
+# OP INSTANTIATION
+# Cluster management
+drain = drain_op(assign_dag)
+sanity_check = manager_op(assign_dag, "sanity_check")
+init_cloudvols = manager_op(assign_dag, "init_cloudvols")
+init_db = manager_op(assign_dag, "init_db")
+
+scale_up_cluster_cpu0 = scale_up_cluster_op(
+    assign_dag, "synaptor-cpu0", "synaptor-cpu", 1, MAX_CLUSTER_SIZE, "cluster"
+)
+scale_down_cluster_cpu0 = scale_down_cluster_op(
+    assign_dag, "synaptor-cpu0", "synaptor-cpu", 0, "cluster"
+)
+scale_up_cluster_gpu = scale_up_cluster_op(
+    assign_dag, "synaptor-gpu", "synaptor-gpu", 1, MAX_CLUSTER_SIZE, "cluster"
+)
+scale_down_cluster_gpu = scale_down_cluster_op(
+    assign_dag, "synaptor-gpu", "synaptor-gpu", 0, "cluster"
+)
+scale_up_cluster_cpu1 = scale_up_cluster_op(
+    assign_dag, "synaptor-cpu1", "synaptor-cpu", 1, MAX_CLUSTER_SIZE, "cluster"
+)
+scale_down_cluster_cpu1 = scale_down_cluster_op(
+    assign_dag, "synaptor-cpu1", "synaptor-cpu", 0, "cluster"
+)
+
+generate_self_destruct_cpu0 = generate_op(assign_dag, "self_destruct", tag="cpu0")
+wait_self_destruct_cpu0 = wait_op(assign_dag, "self_destruct_cpu0")
+generate_self_destruct_gpu = generate_op(assign_dag, "self_destruct", tag="gpu")
+wait_self_destruct_gpu = wait_op(assign_dag, "self_destruct_gpu")
+generate_self_destruct_cpu1 = generate_op(assign_dag, "self_destruct", tag="cpu1")
+wait_self_destruct_cpu1 = wait_op(assign_dag, "self_destruct_cpu1")
+
+
+# Ops that do actual work
+cpu0_workers = [synaptor_op(assign_dag, i, tag="cpu0") for i in range(MAX_CLUSTER_SIZE)]
+gpu_workers = [
+    synaptor_op(assign_dag, i, op_queue_name="synaptor-gpu", tag="gpu")
+    for i in range(MAX_CLUSTER_SIZE)
+]
+cpu1_workers = [synaptor_op(assign_dag, i, tag="cpu1") for i in range(MAX_CLUSTER_SIZE)]
+
+generate_chunk_ccs = generate_op(assign_dag, "chunk_ccs")
+wait_chunk_ccs = wait_op(assign_dag, "chunk_ccs")
+
+generate_match_contins = generate_op(assign_dag, "match_contins")
+wait_match_contins = wait_op(assign_dag, "match_contins")
+
+generate_seg_graph_ccs = generate_op(assign_dag, "seg_graph_ccs")
+wait_seg_graph_ccs = wait_op(assign_dag, "seg_graph_ccs")
+
+generate_chunk_seg_map = generate_op(assign_dag, "chunk_seg_map")
+wait_chunk_seg_map = wait_op(assign_dag, "chunk_seg_map")
+
+generate_merge_seginfo = generate_op(assign_dag, "merge_seginfo")
+wait_merge_seginfo = wait_op(assign_dag, "merge_seginfo")
+
+generate_chunk_edges = generate_op(assign_dag, "chunk_edges")
+wait_chunk_edges = wait_op(assign_dag, "chunk_edges")
+
+generate_pick_edge = generate_op(assign_dag, "pick_edge")
+wait_pick_edge = wait_op(assign_dag, "pick_edge")
+
+generate_merge_dups = generate_op(assign_dag, "merge_dups")
+wait_merge_dups = wait_op(assign_dag, "merge_dups")
+
+generate_merge_dup_maps = generate_op(assign_dag, "merge_dup_maps")
+wait_merge_dup_maps = wait_op(assign_dag, "merge_dup_maps")
+
+generate_remap = generate_op(assign_dag, "remap")
+wait_remap = wait_op(assign_dag, "remap")
+
+
+# DEPENDENCIES
+# Drain old tasks before doing anything
+drain >> sanity_check >> init_cloudvols >> init_db  # >> generate_ngl_link
+
+# Worker dag
+(
+    init_db
+    # Segmentation wave (CPU)
+    >> scale_up_cluster_cpu0
+    >> cpu0_workers
+    >> scale_down_cluster_cpu0
+    # Chunk-wise synapse assignment (GPU)
+    >> scale_up_cluster_gpu
+    >> gpu_workers
+    >> scale_down_cluster_gpu
+    # Merging synapse assignment (CPU)
+    >> scale_up_cluster_cpu1
+    >> cpu1_workers
+    >> scale_down_cluster_cpu1
+)
+
+# Generator/task dag
+(
+    init_db
+    # Segmentation wave (CPU)
+    >> generate_chunk_ccs
+    >> wait_chunk_ccs
+    >> generate_match_contins
+    >> wait_match_contins
+    >> generate_seg_graph_ccs
+    >> wait_seg_graph_ccs
+    >> generate_chunk_seg_map
+    >> wait_chunk_seg_map
+    >> generate_merge_seginfo
+    >> wait_merge_seginfo
+    >> generate_self_destruct_cpu0
+    >> wait_self_destruct_cpu0
+)
+
+(
+    wait_self_destruct_cpu0
+    # Chunk-wise synapse assignment (GPU)
+    >> generate_chunk_edges
+    >> wait_chunk_edges
+    >> generate_self_destruct_gpu
+    >> wait_self_destruct_gpu
+)
+
+(
+    wait_self_destruct_gpu
+    # Merging synapse assignment (CPU)
+    >> generate_pick_edge
+    >> wait_pick_edge
+    >> generate_merge_dups
+    >> wait_merge_dups
+    >> generate_merge_dup_maps
+    >> wait_merge_dup_maps
+    >> generate_remap
+    >> wait_remap
+    >> generate_self_destruct_cpu1
+    >> wait_self_destruct_cpu1
+)

--- a/dags/synaptor_ops.py
+++ b/dags/synaptor_ops.py
@@ -1,0 +1,191 @@
+"""Operator functions for synaptor DAGs."""
+import os
+from typing import Optional
+
+from airflow import DAG
+from airflow.utils.weight_rule import WeightRule
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable, BaseOperator as Operator
+
+from worker_op import worker_op
+from igneous_and_cloudvolume import check_queue
+
+from slack_message import task_failure_alert, task_done_alert
+from kombu_helper import drain_messages
+
+
+# hard-coding these for now
+MOUNT_POINT = "/root/.cloudvolume/secrets/"
+SYNAPTOR_IMAGE = "gcr.io/zetta-lee-fly-vnc-001/synaptor:nazgul"
+TASK_QUEUE_NAME = "synaptor"
+
+
+# Python callables (for PythonOperators)
+def generate_ngl_link_op() -> None:
+    """Generates a neuroglancer link to view the results."""
+    pass
+
+
+# Op functions
+def drain_op(
+    dag: DAG,
+    task_queue_name: Optional[str] = TASK_QUEUE_NAME,
+    queue: Optional[str] = "manager",
+) -> Operator:
+    """Drains leftover messages from the RabbitMQ."""
+    from airflow import configuration as conf
+
+    broker_url = conf.get("celery", "broker_url")
+
+    return PythonOperator(
+        task_id="drain_messages",
+        python_callable=drain_messages,
+        priority_weight=100_000,
+        op_args=(broker_url, task_queue_name),
+        weight_rule=WeightRule.ABSOLUTE,
+        on_failure_callback=task_failure_alert,
+        on_success_callback=task_done_alert,
+        queue="manager",
+        dag=dag,
+    )
+
+
+def manager_op(dag: DAG, synaptor_task_name: str, queue: str = "manager") -> Operator:
+    """An operator fn for running synaptor tasks on the airflow node."""
+    config_path = os.path.join(MOUNT_POINT, "synaptor_param")
+    command = f"{synaptor_task_name} {config_path}"
+
+    # these variables will be mounted in the containers
+    variables = ["synaptor_param"]
+
+    return worker_op(
+        variables=variables,
+        mount_point=MOUNT_POINT,
+        task_id=synaptor_task_name,
+        command=command,
+        force_pull=True,
+        on_failure_callback=task_failure_alert,
+        on_success_callback=task_done_alert,
+        image=SYNAPTOR_IMAGE,
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        queue=queue,
+        dag=dag,
+    )
+
+
+def generate_op(
+    dag: DAG,
+    taskname: str,
+    op_queue_name: Optional[str] = "manager",
+    task_queue_name: Optional[str] = TASK_QUEUE_NAME,
+    tag: Optional[str] = None,
+) -> Operator:
+    """Generates tasks to run and adds them to the RabbitMQ."""
+    from airflow import configuration as conf
+
+    broker_url = conf.get("celery", "broker_url")
+    config_path = os.path.join(MOUNT_POINT, "synaptor_param")
+
+    command = (
+        f"generate {taskname} {config_path}"
+        f" --queueurl {broker_url}"
+        f" --queuename {task_queue_name}"
+    )
+
+    # these variables will be mounted in the containers
+    variables = add_secrets_if_defined(["synaptor_param"])
+
+    task_id = f"generate_{taskname}" if tag is None else f"generate_{taskname}_{tag}"
+
+    return worker_op(
+        variables=variables,
+        mount_point=MOUNT_POINT,
+        task_id=task_id,
+        command=command,
+        force_pull=True,
+        on_failure_callback=task_failure_alert,
+        on_success_callback=task_done_alert,
+        image=SYNAPTOR_IMAGE,
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        queue=op_queue_name,
+        dag=dag,
+    )
+
+
+def synaptor_op(
+    dag: DAG,
+    i: int,
+    op_queue_name: Optional[str] = "synaptor-cpu",
+    task_queue_name: Optional[str] = TASK_QUEUE_NAME,
+    tag: Optional[str] = None,
+) -> Operator:
+    """Runs a synaptor worker until it receives a self-destruct task."""
+    from airflow import configuration as conf
+
+    broker_url = conf.get("celery", "broker_url")
+    config_path = os.path.join(MOUNT_POINT, "synaptor_param")
+
+    command = (
+        f"worker --configfilename {config_path}"
+        f" --queueurl {broker_url} "
+        f" --queuename {task_queue_name}"
+        " --lease_seconds 300"
+    )
+
+    # these variables will be mounted in the containers
+    variables = add_secrets_if_defined(["synaptor_param"])
+
+    task_id = f"worker_{i}" if tag is None else f"worker_{tag}_{i}"
+
+    return worker_op(
+        variables=variables,
+        mount_point=MOUNT_POINT,
+        task_id=task_id,
+        command=command,
+        force_pull=True,
+        image=SYNAPTOR_IMAGE,
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        queue=op_queue_name,
+        dag=dag,
+        # qos='quality of service'
+        # this turns of a 5-minute failure timer that can kill nodes between
+        # task waves or during database tasks
+        qos=False,
+        retries=100,
+        retry_exponential_backoff=False,
+    )
+
+
+def wait_op(dag: DAG, taskname: str) -> Operator:
+    """Waits for a task to finish."""
+    return PythonOperator(
+        task_id=f"wait_for_queue_{taskname}",
+        python_callable=check_queue,
+        op_args=(TASK_QUEUE_NAME,),
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        on_success_callback=task_done_alert,
+        queue="manager",
+        dag=dag,
+    )
+
+
+# Helper functions
+def add_secrets_if_defined(variables: list[str]) -> list[str]:
+    """Adds CloudVolume secret files to the mounted variables if defined.
+
+    Synaptor still needs to store the google-secret.json file sometimes
+    bc it currently uses an old version of gsutil.
+    """
+    maybe_aws = Variable.get("aws-secret.json", None)
+    maybe_gcp = Variable.get("google-secret.json", None)
+
+    if maybe_aws is not None:
+        variables.append("aws-secret.json")
+    if maybe_gcp is not None:
+        variables.append("google-secret.json")
+
+    return variables

--- a/dags/worker_op.py
+++ b/dags/worker_op.py
@@ -1,5 +1,6 @@
 def worker_op(**kwargs):
     from custom.docker_custom import DockerWithVariablesOperator
+    default_args = kwargs.get("default_args", {})
     return DockerWithVariablesOperator(
         variables=kwargs["variables"],
         mount_point=kwargs.get("mount_point", None),
@@ -7,7 +8,7 @@ def worker_op(**kwargs):
         command=kwargs["command"],
         xcom_all=kwargs.get('xcom_all', False),
         force_pull=kwargs.get("force_pull", False),
-        default_args=kwargs.get("default_args", {}),
+        default_args=default_args,
         on_failure_callback=kwargs.get("on_failure_callback", None),
         on_retry_callback=kwargs.get("on_retry_callback", None),
         on_success_callback=kwargs.get("on_success_callback", None),
@@ -17,8 +18,8 @@ def worker_op(**kwargs):
         execution_timeout=kwargs.get("execution_timeout", None),
         queue=kwargs["queue"],
         dag=kwargs["dag"],
-        qos=kwargs.get("qos", True),
-        retries=kwargs.get("retries", 0),
-        retry_delay=kwargs.get("retry_delay", 60),
-        retry_exponential_backoff=kwargs.get("retry_exponential_backoff", False),
+        qos=kwargs.get("qos", default_args.get("qos", True)),
+        retries=kwargs.get("retries", default_args.get("retries", 0)),
+        retry_delay=kwargs.get("retry_delay", default_args.get("retry_delay", 60)),
+        retry_exponential_backoff=kwargs.get("retry_exponential_backoff", default_args.get("retry_exponential_backoff", False)),
     )


### PR DESCRIPTION
This PR contains the set of commits that introduce the synaptor DAGs. Part 3 will add the slackbot changes.

Within part 2, there are two files:
* `synaptor_ops.py` defines functions that return operators that are mostly specific to synaptor function. Two exceptions to this are `drain_op` and `wait_op`, which use the python callables from `kombu_helper.py`. These could probably be moved into `helper_ops.py` if desired.
* `synaptor_dags.py` defines the synaptor workflow DAGs. There are four DAGs: (1) an initial sanity check function for configuration files, (2) connected component segmentation using a file backend, (3) connected component segmentation using a database backend, and (4) combined segmentation and synapse assignment using a database backend.

There are a couple of remaining tasks that will probably be in future PRs:
* There are a couple of database management tasks that I've left out for now (indexing database tables after I fill them). These are mentioned in some of the `synaptor_dags.py` comments.
* Large volumes require a larger instance to run the final connected components step. I should add new steps to scale up/down these nodes accordingly when this is required.