### PR TITLE
Synaptor PR part 3/3: slack_bot updates

### DIFF
--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -12,7 +12,7 @@ from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
 
-seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu"]
+seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check"]
 
 
 def latest_task():
@@ -92,6 +92,11 @@ def trigger_or_clear_dag(dag_id):
 def sanity_check():
     dag_id = "sanity_check"
     trigger_or_clear_dag(dag_id)
+
+
+def synaptor_sanity_check():
+    """Runs the synaptor sanity check DAG."""
+    trigger_or_clear_dag("synaptor_sanity_check")
 
 
 def chunkflow_set_env():

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -65,6 +65,7 @@ def update_user_info(userid):
 
 
 def check_running():
+    """Checks whether the DAGs within the seuron_dags list (above) is running."""
     for d in seuron_dags:
         state, exec_date = dag_state(d)
         if state == "running":

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -12,7 +12,7 @@ from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
 
-seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg"]
+seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment"]
 
 
 def latest_task():
@@ -195,6 +195,15 @@ def run_synaptor_db_seg():
         return False
 
     run_dag("synaptor_db_seg")
+    return True
+
+
+def run_synaptor_assignment():
+    """Runs the synaptor assignment DAG."""
+    if check_running():
+        return False
+
+    run_dag("synaptor_assignment")
     return True
 
 

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -12,7 +12,7 @@ from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
 
-seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg"]
+seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg"]
 
 
 def latest_task():
@@ -186,6 +186,15 @@ def run_synaptor_file_seg():
         return False
 
     run_dag("synaptor_file_seg")
+    return True
+
+
+def run_synaptor_db_seg():
+    """Runs the synaptor database segmentation DAG."""
+    if check_running():
+        return False
+
+    run_dag("synaptor_db_seg")
     return True
 
 

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -12,7 +12,7 @@ from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
 
-seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check"]
+seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg"]
 
 
 def latest_task():
@@ -177,6 +177,15 @@ def run_contact_surface():
         return False
 
     run_dag(dag_id)
+    return True
+
+
+def run_synaptor_file_seg():
+    """Runs the synaptor file segmentation DAG."""
+    if check_running():
+        return False
+
+    run_dag("synaptor_file_seg")
     return True
 
 

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -8,7 +8,7 @@ from airflow_api import get_variable, run_segmentation, \
     update_slack_connection, check_running, dag_state, set_variable, \
     sanity_check, chunkflow_set_env, run_inference, run_contact_surface, \
     mark_dags_success, run_dag, run_igneous_tasks, run_custom_tasks, \
-    synaptor_sanity_check, run_synaptor_file_seg
+    synaptor_sanity_check, run_synaptor_file_seg, run_synaptor_db_seg
 from bot_info import slack_token, botid, workerid, broker_url
 from kombu_helper import drain_messages
 from google_metadata import get_project_data, get_instance_data, get_instance_metadata, set_instance_metadata, gce_external_ip
@@ -314,6 +314,18 @@ def synaptor_file_seg(msg):
     run_synaptor_file_seg()
 
 
+def synaptor_db_seg(msg):
+    """Runs the file segmentation DAG."""
+    if check_running():
+        replyto(msg, "Busy right now")
+        return
+
+    replyto(msg, "Running synaptor file segmentation. Please wait.")
+    create_run_token(msg)
+    update_metadata(msg)
+    run_synaptor_db_seg()
+
+
 def run_igneous_scripts(msg):
     _, payload = download_file(msg)
     if payload:
@@ -495,6 +507,11 @@ def dispatch_command(cmd, msg):
     elif cmd in ["runsynaptorfileseg",
                  "runsynaptorfilesegmentation"]:
         synaptor_file_seg(msg)
+    elif cmd in ["runsynaptordbseg",
+                 "runsynaptordatabaseseg",
+                 "runsynaptordbsegmentation",
+                 "runsynaptordatabasesegmentation"]:
+        synaptor_db_seg(msg)
     else:
         replyto(msg, "Sorry I do not understand, please try again.")
 

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -8,7 +8,8 @@ from airflow_api import get_variable, run_segmentation, \
     update_slack_connection, check_running, dag_state, set_variable, \
     sanity_check, chunkflow_set_env, run_inference, run_contact_surface, \
     mark_dags_success, run_dag, run_igneous_tasks, run_custom_tasks, \
-    synaptor_sanity_check, run_synaptor_file_seg, run_synaptor_db_seg
+    synaptor_sanity_check, run_synaptor_file_seg, run_synaptor_db_seg, \
+    run_synaptor_assignment
 from bot_info import slack_token, botid, workerid, broker_url
 from kombu_helper import drain_messages
 from google_metadata import get_project_data, get_instance_data, get_instance_metadata, set_instance_metadata, gce_external_ip
@@ -326,6 +327,18 @@ def synaptor_db_seg(msg):
     run_synaptor_db_seg()
 
 
+def synaptor_assignment(msg):
+    """Runs the file segmentation DAG."""
+    if check_running():
+        replyto(msg, "Busy right now")
+        return
+
+    replyto(msg, "Running synaptor synapse assignment. Please wait.")
+    create_run_token(msg)
+    update_metadata(msg)
+    run_synaptor_assignment()
+
+
 def run_igneous_scripts(msg):
     _, payload = download_file(msg)
     if payload:
@@ -512,6 +525,9 @@ def dispatch_command(cmd, msg):
                  "runsynaptordbsegmentation",
                  "runsynaptordatabasesegmentation"]:
         synaptor_db_seg(msg)
+    elif cmd in ["runsynaptorassignment",
+                 "runsynaptorsynapseassignment"]:
+        synaptor_assignment(msg)
     else:
         replyto(msg, "Sorry I do not understand, please try again.")
 

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -132,6 +132,7 @@ def cancel_run(msg):
     drain_messages(broker_url, "custom-cpu")
     drain_messages(broker_url, "custom-gpu")
     drain_messages(broker_url, "chunkflow")
+    drain_messages(broker_url, "synaptor")
 
     time.sleep(30)
 


### PR DESCRIPTION
This PR contains the slack bot changes. The change we recently discussed addressing a race condition will be put into a separate request.

The structure of these commits are each similar. They each add a new slack bot command for the DAGs in part 2. If we decide to merge these DAGs together it should be quick work to also merge these commands. I can also squash these DAG commits together if you prefer to read them that way.

Each of these commands have been tested to trigger the DAGs and accept cancels.

I also added one commit to add a docstring to help guide future readers to the `seuron_dags` variable so implementing `cancel_run` might be a bit easier later.