### PR TITLE
Initial corgie functionality

### DIFF
--- a/dags/corgie.py
+++ b/dags/corgie.py
@@ -1,0 +1,180 @@
+"""A simple corgie DAG for cluster management.
+
+The overall structure is to start a cluster of failure-tolerant worker nodes
+and a single manager node. The manager node will control which tasks are run
+on the workers through the corgie command, and will succeed or fail depending
+on how the workers process their tasks.
+
+Regardless of whether the manager succeeds or fails, we always run a scale down
+op to turn off the the worker cluster. This means that the worker nodes will always
+"fail" eventually, but a following operation then marks these task instances with
+the success or failure of the manager node.
+"""
+import json
+from typing import Optional
+from datetime import datetime
+
+from airflow import DAG
+from airflow.hooks.base_hook import BaseHook
+from airflow.utils.weight_rule import WeightRule
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable, DagRun, DagBag, BaseOperator as Operator
+
+from worker_op import worker_op
+from slack_message import task_failure_alert, task_done_alert
+from helper_ops import (
+    scale_up_cluster_op,
+    scale_down_cluster_op,
+    mark_success_or_failure_op,
+)
+
+
+CORGIE_IMAGE = "gcr.io/zetta-lee-fly-vnc-001/test-worm-alignment-redo"
+CORGIE_CLUSTERS = ["corgie-cpu", "corgie_gpu"]
+CLUSTER = Variable.get("active_corgie_cluster", "corgie-gpu")
+COMMAND = Variable.get("corgie_command", "")
+
+
+default_args = {
+    "owner": "seuronbot",
+    "depends_on_past": False,
+    "start_date": datetime(2022, 4, 5),
+    "catchup": False,
+    "retries": 0,
+}
+
+
+# Op functions
+def sanity_check_op(
+    dag: DAG, command: Optional[str] = "", queue: Optional[str] = "manager"
+) -> Operator:
+    """An operator fn for sanity checking a corgie command on the airflow node."""
+    command = f"sanity_check {command}"
+    # temporary while we use SQS
+    variables = {
+        "aws-secret.json": "/root/.cloudvolume/secrets",
+        "credentials": "/root/.aws",
+    }
+
+    return worker_op(
+        task_id="sanity_check",
+        command=command,
+        variables=variables,
+        mount_point=None,
+        force_pull=True,
+        on_failure_callback=task_failure_alert,
+        on_success_callback=task_done_alert,
+        image=CORGIE_IMAGE,
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        queue=queue,
+        dag=dag,
+    )
+
+
+def corgie_manager_op(
+    dag: DAG, command: Optional[str] = "", queue: Optional[str] = "manager"
+) -> Operator:
+    """An operator fn for running a corgie command on the airflow node."""
+    # temporary while we use SQS
+    variables = {
+        "aws-secret.json": "/root/.cloudvolume/secrets",
+        "credentials": "/root/.aws",
+    }
+
+    return worker_op(
+        task_id="corgie_manager",
+        command=command,
+        variables=variables,
+        mount_point=None,
+        force_pull=True,
+        on_failure_callback=task_failure_alert,
+        on_success_callback=task_done_alert,
+        image=CORGIE_IMAGE,
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        queue=queue,
+        dag=dag,
+        qos=False,
+    )
+
+
+def corgie_worker_op(
+    dag: DAG, worker_id: int, queue: Optional[str] = CLUSTER
+) -> Operator:
+    """An operator fn for running the corgie workers."""
+    # temporary for testing
+    queueurl = "seuron-corgie-testing"
+    # temporary while we use SQS
+    variables = {
+        "aws-secret.json": "/root/.cloudvolume/secrets",
+        "credentials": "/root/.aws",
+    }
+
+    command = f"corgie-worker --queue_name {queueurl} --lease_seconds 600 --verbose"
+    return worker_op(
+        task_id=f"corgie_worker_{worker_id}",
+        command=command,
+        force_pull=True,
+        variables=variables,
+        mount_point=None,
+        image=CORGIE_IMAGE,
+        priority_weight=100_000,
+        weight_rule=WeightRule.ABSOLUTE,
+        queue=queue,
+        dag=dag,
+        qos=False,
+        retries=1000,
+        retry_exponential_backoff=False,
+    )
+
+
+# Helper fn
+def max_cluster_size() -> int:
+    """Reads the max cluster size from the InstanceGroups connection."""
+    cluster_info = json.loads(BaseHook.get_connection("InstanceGroups").extra)
+
+    try:
+        return cluster_info[CLUSTER][0]["max_size"]
+
+    except KeyError:
+        raise KeyError(f"cluster {CLUSTER} not found in InstanceGroups connection")
+
+
+# DAG Definition
+# DAG 1: A sanity-check dry run
+dry_run = DAG(
+    "corgie_dry_run",
+    default_args=default_args,
+    schedule_interval=None,
+    tags=["corgie"],
+)
+
+sanity_check_op(dry_run, COMMAND)
+
+
+# DAG 2: Actually running a corgie command with workers
+MAX_CLUSTER_SIZE = max_cluster_size()
+
+corgie_dag = DAG(
+    "corgie", default_args=default_args, schedule_interval=None, tags=["corgie"],
+)
+
+# skipping sanity checks until the function is implemented
+# sanity_check = sanity_check_op(corgie_dag, COMMAND)
+scale_up_cluster = scale_up_cluster_op(
+    corgie_dag, "corgie", CLUSTER, 1, MAX_CLUSTER_SIZE, "cluster"
+)
+workers = [corgie_worker_op(corgie_dag, i) for i in range(MAX_CLUSTER_SIZE)]
+run_corgie = corgie_manager_op(corgie_dag, COMMAND)
+scale_down_cluster = scale_down_cluster_op(
+    corgie_dag, "corgie", CLUSTER, 0, "cluster", trigger_rule="all_done"
+)
+mark_op = mark_success_or_failure_op(corgie_dag, "corgie", "corgie_manager")
+
+# Dependencies
+
+# skipping sanity checks until the function is implemented
+# sanity_check >> scale_up_cluster >> run_corgie >> scale_down_cluster >> mark_op
+scale_up_cluster >> run_corgie >> scale_down_cluster >> mark_op
+scale_up_cluster >> workers

--- a/dags/helper_ops.py
+++ b/dags/helper_ops.py
@@ -98,7 +98,7 @@ def wait_op(dag, process):
     )
 
 
-def scale_up_cluster_op(dag, stage, key, initial_size, total_size, queue):
+def scale_up_cluster_op(dag, stage, key, initial_size, total_size, queue, trigger_rule="one_success"):
     return PythonOperator(
         task_id='resize_{}_{}'.format(stage, total_size),
         python_callable=ramp_up_cluster,
@@ -106,13 +106,13 @@ def scale_up_cluster_op(dag, stage, key, initial_size, total_size, queue):
         default_args=default_args,
         weight_rule=WeightRule.ABSOLUTE,
         priority_weight=1000,
-        trigger_rule="one_success",
+        trigger_rule=trigger_rule,
         queue=queue,
         dag=dag
     )
 
 
-def scale_down_cluster_op(dag, stage, key, size, queue):
+def scale_down_cluster_op(dag, stage, key, size, queue, trigger_rule="all_success"):
     return PythonOperator(
         task_id='resize_{}_{}'.format(stage, size),
         python_callable=ramp_down_cluster,
@@ -120,7 +120,7 @@ def scale_down_cluster_op(dag, stage, key, size, queue):
         default_args=default_args,
         weight_rule=WeightRule.ABSOLUTE,
         priority_weight=1000,
-        trigger_rule="all_success",
+        trigger_rule=trigger_rule,
         queue=queue,
         dag=dag
     )

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -12,7 +12,7 @@ from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
 
-seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment"]
+seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment", "corgie"]
 
 
 def latest_task():
@@ -205,6 +205,24 @@ def run_synaptor_assignment():
         return False
 
     run_dag("synaptor_assignment")
+    return True
+
+
+def run_corgie_sanity_check() -> bool:
+    """Runs the corgie sanity check DAG."""
+    if check_running():
+        return False
+
+    run_dag("corgie_dry_run")
+    return True
+
+
+def run_corgie() -> bool:
+    """Runs the corgie DAG."""
+    if check_running():
+        return False
+
+    run_dag("corgie")
     return True
 
 


### PR DESCRIPTION
Implements some initial DAGs for corgie that allow users to run corgie commands through slack while airflow manages the cluster. The main `corgie` DAG is meant to be simple, and a few stubs exist to support a "sanity check" DAG once a general sanity check function is implemented in corgie.

## Corgie DAG structure
* Runs a single manager task instance and N workers, where N is based on the maximum cluster size connection.
* The manager node monitors the queue, and will return when the workers finish.
* When the manager returns, we scale down the cluster regardless of its status, and mark the worker task instances with the manager's status.

## General changes:
* Adds a keyword argument to the `scale_[up,down]_cluster_op` helper functions. For this corgie DAG, we want to scale down the cluster whenever the manager node fails.
* Adds a `mark_success_or_failure_op` that marks the rest of a DAG run's task instances with the status of a single "anchor task". This is useful to signal to airflow that the worker nodes are finished and to keep the airflow interface clean.
* Adds "flexible variable mounting" to `DockerOperatorWithVariables`. This allows a user to specify a dictionary mapping the variables that they want mounted to multiple separate locations within the container. The implementation of this just makes subdirectories in the same temporary directory as the original.

## Slack commands
* `update corgie cluster` sets an airflow variable that determines which cluster will be controlled by airflow. This should not run if the cluster is already processing a command.
* `run corgie command` starts the corgie DAG above
* `run corgie sanity check` starts the stub sanity check DAG (this will currently fail).

## Review notes
The most controversial changes are in commits 36c05a8cefea2124a612e46602922c8aaab1fc6f and 8f8018edc841cbb935e7d8d21887ed5cd21c436d. Commit 36c05a8cefea2124a612e46602922c8aaab1fc6f changes the behavior of the DockerWithVariablesOperator, and commit 8f8018edc841cbb935e7d8d21887ed5cd21c436d adds some extra extraction functions to parse the user's command. These commands probably aren't perfect and I could use input if there are extra bugs I haven't considered.

## To-do:
* Extract the SQS queue from the user's corgie command and point the worker nodes to it.
* If the user passes no command when asking the bot to run, it will try to run a command "None". This makes the cluster fail within a minute or two, but we should still try harder to avoid this failure.
* Allow the corgie command message to specify which cluster to use? (one fewer slack message)