### PR TITLE
Fix task retry in chunkflow dags

### DIFF
--- a/dags/worker_op.py
+++ b/dags/worker_op.py
@@ -1,6 +1,7 @@
 def worker_op(**kwargs):
     from custom.docker_custom import DockerWithVariablesOperator
-    default_args = kwargs.get("default_args", {})
+    dag = kwargs['dag']
+    default_args = kwargs.get("default_args", dag.default_args)
     return DockerWithVariablesOperator(
         variables=kwargs["variables"],
         mount_point=kwargs.get("mount_point", None),
@@ -17,7 +18,7 @@ def worker_op(**kwargs):
         weight_rule=kwargs["weight_rule"],
         execution_timeout=kwargs.get("execution_timeout", None),
         queue=kwargs["queue"],
-        dag=kwargs["dag"],
+        dag=dag,
         qos=kwargs.get("qos", default_args.get("qos", True)),
         retries=kwargs.get("retries", default_args.get("retries", 0)),
         retry_delay=kwargs.get("retry_delay", default_args.get("retry_delay", 60)),


### PR DESCRIPTION
Chunkflow dags set the retry policy using default parameters giving to
the dag constructors, so there is no explicit default_args given when
creating the operators. Fallback to the default_args in the dag if no
default_args is passed to worker_op. Default_args will be an empty dict
by default so there is no need to add another layer of fallback.