### PR TITLE
Obtain botUserID using slack api

### DIFF
--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -125,7 +125,6 @@ services:
         environment:
             <<: *airflow-common-env
             SLACK_TOKEN:
-            BOTUSERID:
             DEPLOYMENT:
         command: python slackbot/slack_bot.py
         deploy:

--- a/slackbot/bot_info.py
+++ b/slackbot/bot_info.py
@@ -1,5 +1,13 @@
 from os import environ
+import slack_sdk as slack
+
+
+def get_botid():
+    client = slack.WebClient(token=slack_token)
+    auth_info = client.auth_test()
+    return f'<@{auth_info["user_id"]}>'
+
 slack_token = environ["SLACK_TOKEN"]
-botid = "<@{}>".format(environ["BOTUSERID"])
+botid = get_botid()
 workerid = "seuron-worker-"+environ["DEPLOYMENT"]
 broker_url = environ['AIRFLOW__CELERY__BROKER_URL']


### PR DESCRIPTION
The id of a bot user obscure and hard to find, I realized we can obtain it from slack api automatically after some googling. There will be a matching pr for the deployment repo.