### PR TITLE
Seuron notification

### DIFF
--- a/cloud/google/cloud-deployment.yaml
+++ b/cloud/google/cloud-deployment.yaml
@@ -17,6 +17,7 @@ resources:
           composeLocation: https://raw.githubusercontent.com/seung-lab/seuron/main/deploy/docker-compose-CeleryExecutor.yml
           slack:
             botToken: # bot token for slack
+            notificationChannel: seuron-alerts
           nginx:
             user: # nginx username
             password: # nginx password, set it to null if you do not want a password

--- a/cloud/google/manager.py
+++ b/cloud/google/manager.py
@@ -5,6 +5,7 @@ from common import INSTALL_DOCKER_CMD, INSTALL_NVIDIA_DOCKER_CMD, CELERY_CMD, PA
 def GenerateEnvironVar(context, hostname_manager):
     env_variables = {
         'SLACK_TOKEN': context.properties['slack']['botToken'],
+        'SLACK_NOTIFICATION_CHANNEL': context.properties['slack']['notificationChannel'],
         'DEPLOYMENT': context.env['deployment'],
         'ZONE': context.properties['zone'],
         'SEURON_TAG': context.properties['seuronImage'],

--- a/dags/cluster_dag.py
+++ b/dags/cluster_dag.py
@@ -46,7 +46,7 @@ def check_queue(queue):
     import requests
     ret = requests.get("http://rabbitmq:15672/api/queues/%2f/{}".format(queue), auth=('guest', 'guest'))
     if not ret.ok:
-        slack_message(f"Cannot get info for queue {queue}, assume 0 tasks", channel="#seuron-alerts")
+        slack_message(f"Cannot get info for queue {queue}, assume 0 tasks", notification=True)
         return 0
     queue_status = ret.json()
     return queue_status["messages"]
@@ -57,7 +57,7 @@ def cluster_control():
         cluster_info = json.loads(BaseHook.get_connection("InstanceGroups").extra)
         target_sizes = Variable.get("cluster_target_size", deserialize_json=True)
     except:
-        slack_message(":exclamation:Failed to load the cluster information from connection {}".format("InstanceGroups"), channel="#seuron-alerts")
+        slack_message(":exclamation:Failed to load the cluster information from connection {}".format("InstanceGroups"), notification=True)
         return
     for key in cluster_info:
         if key in target_sizes:
@@ -72,7 +72,7 @@ def cluster_control():
                     total_size = gapi.get_cluster_size(project_id, cluster_info[key])
                     total_target_size = gapi.get_cluster_target_size(project_id, cluster_info[key])
                 except:
-                    slack_message(":exclamation:Failed to get the {} cluster information from google.".format(key), channel="#seuron-alerts")
+                    slack_message(":exclamation:Failed to get the {} cluster information from google.".format(key), notification=True)
                     continue
                 if num_tasks < total_size:
                     if 10 < num_tasks < total_size//10:
@@ -98,7 +98,7 @@ def cluster_control():
                             slack_message(":arrow_up: ramping up cluster {} from {} to {} instances".format(key, total_target_size, new_target_size))
                     else:
                         if (total_target_size != 0):
-                            slack_message(":information_source: status of cluster {}: {} out of {} instances up and running".format(key, total_size, total_target_size), channel="#seuron-alerts")
+                            slack_message(":information_source: status of cluster {}: {} out of {} instances up and running".format(key, total_size, total_target_size), notification=True)
 
             else:
                 total_target_size = gapi.get_cluster_target_size(project_id, cluster_info[key])

--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -97,7 +97,7 @@ def resize_instance_group(project_id, instance_group, size):
         request = service.instanceGroupManagers().resize(project=project_id, zone=ig['zone'], instanceGroupManager=ig['name'], size=ig_size)
         response = request.execute()
         print(json.dumps(response, indent=2))
-        slack_message(":information_source: resize instance group {} to {} instances".format(ig['name'], ig_size), channel="#seuron-alerts")
+        slack_message(":information_source: resize instance group {} to {} instances".format(ig['name'], ig_size), notification=True)
         target_size -= ig_size
         if not downsize and target_size == 0:
             break

--- a/dags/heartbeat_dag.py
+++ b/dags/heartbeat_dag.py
@@ -71,7 +71,7 @@ def get_num_task_instances(session):
 
     message = '''*Pipeline heartbeat:*
 *{}* tasks running, *{}* tasks queued, *{}* tasks up for retry'''.format(running, queued, up_for_retry)
-    slack_message(message, channel="#seuron-alerts")
+    slack_message(message, notification=True)
 
 latest = LatestOnlyOperator(
     task_id='latest_only',

--- a/dags/slack_message.py
+++ b/dags/slack_message.py
@@ -1,4 +1,4 @@
-def slack_message(msg, channel=None, broadcast=False, attachment=None):
+def slack_message(msg, notification=False, broadcast=False, attachment=None):
     from param_default import SLACK_CONN_ID
     from airflow.hooks.base_hook import BaseHook
     import slack_sdk as slack
@@ -15,14 +15,13 @@ def slack_message(msg, channel=None, broadcast=False, attachment=None):
     slack_channel = slack_extra['channel']
     slack_thread = slack_extra['thread_ts']
 
-    if channel is not None:
-        slack_channel = channel
+    if notification:
         text="{message}".format(
             message=msg
         )
         sc.chat_postMessage(
             username=slack_workername,
-            channel=channel,
+            channel="#seuron-alerts",
             text=text
         )
     else:

--- a/dags/slack_message.py
+++ b/dags/slack_message.py
@@ -14,6 +14,7 @@ def slack_message(msg, notification=False, broadcast=False, attachment=None):
     slack_username = slack_extra['user']
     slack_channel = slack_extra['channel']
     slack_thread = slack_extra['thread_ts']
+    slack_notification_channel = slack_extra['notification_channel']
 
     if notification:
         text="{message}".format(
@@ -21,7 +22,7 @@ def slack_message(msg, notification=False, broadcast=False, attachment=None):
         )
         sc.chat_postMessage(
             username=slack_workername,
-            channel="#seuron-alerts",
+            channel=slack_notification_channel,
             text=text
         )
     else:

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -108,6 +108,7 @@ services:
         restart: on-failure
         environment:
             <<: *airflow-common-env
+            SLACK_NOTIFICATION_CHANNEL:
             DEPLOYMENT:
             ZONE:
             _AIRFLOW_DB_UPGRADE: 'true'
@@ -167,6 +168,7 @@ services:
         environment:
             <<: *airflow-common-env
             SLACK_TOKEN:
+            SLACK_NOTIFICATION_CHANNEL:
             DEPLOYMENT:
         command: python slackbot/slack_bot.py
         deploy:

--- a/pipeline/init_pipeline.py
+++ b/pipeline/init_pipeline.py
@@ -60,4 +60,4 @@ db_utils.merge_conn(
 db_utils.merge_conn(
         models.Connection(
             conn_id='Slack', conn_type='http',
-            host='localhost'))
+            host='localhost', extra=json.dumps({"notification_channel": os.environ["SLACK_NOTIFICATION_CHANNEL"]})))

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -1,5 +1,5 @@
 import json
-from bot_info import workerid
+from bot_info import workerid, slack_notification_channel
 
 import pendulum
 
@@ -54,7 +54,7 @@ def update_slack_connection(payload, token):
 
     new_conn = Connection(conn_id=conn_id, conn_type='http', host='localhost', login=workerid, password=token)
 
-    new_conn.set_extra(json.dumps(payload, indent=4))
+    new_conn.set_extra(json.dumps({**payload, "notification_channel": slack_notification_channel}, indent=4))
     session.add(new_conn)
     session.commit()
     session.close()

--- a/slackbot/bot_info.py
+++ b/slackbot/bot_info.py
@@ -8,6 +8,7 @@ def get_botid():
     return f'<@{auth_info["user_id"]}>'
 
 slack_token = environ["SLACK_TOKEN"]
+slack_notification_channel = environ["SLACK_NOTIFICATION_CHANNEL"]
 botid = get_botid()
 workerid = "seuron-worker-"+environ["DEPLOYMENT"]
 broker_url = environ['AIRFLOW__CELERY__BROKER_URL']

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -10,7 +10,7 @@ from airflow_api import get_variable, run_segmentation, \
     mark_dags_success, run_dag, run_igneous_tasks, run_custom_tasks, \
     synaptor_sanity_check, run_synaptor_file_seg, run_synaptor_db_seg, \
     run_synaptor_assignment
-from bot_info import slack_token, botid, workerid, broker_url
+from bot_info import slack_token, botid, workerid, broker_url, slack_notification_channel
 from kombu_helper import drain_messages
 from google_metadata import get_project_data, get_instance_data, get_instance_metadata, set_instance_metadata, gce_external_ip
 from copy import deepcopy
@@ -566,7 +566,7 @@ def hello_world(client=None):
     host_ip = update_ip_address()
 
     client.chat_postMessage(
-        channel='#seuron-alerts',
+        channel=slack_notification_channel,
         username=workerid,
         text="Hello from <https://{}/airflow/home|{}>".format(host_ip, host_ip))
 


### PR DESCRIPTION
Adding a deployment option for a slack channel to send seuron runtime messages. No longer use the hard-coded `#seuron-alerts` channel.