### PR TITLE
Fix error when running with python 3.8

### DIFF
--- a/dags/synaptor_ops.py
+++ b/dags/synaptor_ops.py
@@ -1,4 +1,5 @@
 """Operator functions for synaptor DAGs."""
+from __future__ import annotations
 import os
 from typing import Optional
 


### PR DESCRIPTION
Found this issue when testing seuron with [pyston](https://github.com/pyston/pyston), which is a python 3.8 fork. Seems to be a trivial fix, python 3.9 works as well, I do not know if future python will eventually drop the support for List, or if there is a better way to fix this. 