### PR TITLE
Update services

### DIFF
--- a/cloud/google/manager.py
+++ b/cloud/google/manager.py
@@ -57,6 +57,7 @@ sudo openssl genrsa 2048 | tee >(
 
 wget -O compose.yml {context.properties["composeLocation"]}
 
+echo "[rabbitmq_management,rabbitmq_prometheus]." > /enabled_plugins
 
 touch /etc/bootstrap_done
 

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -93,7 +93,7 @@ services:
             POSTGRES_DB:
 
     redis:
-        image: redis:latest
+        image: redis:7-alpine
         ports:
             - "6379:6379"
         healthcheck:

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -24,7 +24,7 @@ x-airflow-common:
 
 services:
     rabbitmq:
-        image: rabbitmq:3.8-management
+        image: rabbitmq:3.10-management
         environment:
             - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit heartbeat 600 consumer_timeout 2592000000
         volumes:
@@ -176,7 +176,7 @@ services:
                 condition: any
 
     proxy:
-        image: nginx:1.13.5-alpine
+        image: nginx:1.23.0-alpine
         restart: always
         ports:
             - target: 443

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -233,15 +233,6 @@ services:
                         $${SSL_BLOCK}\\n
                         proxy_set_header X-Real-IP \\$$remote_addr;\\n
                         proxy_set_header X-Forwarded-For \\$$proxy_add_x_forwarded_for;\\n
-                        if (\\$$http_referer ~* \\\".*\\/rabbitmq\\/*.*\\\") {\\n
-                            set \\$$is_rabbitmq \\\"A\\\";\\n
-                        }\\n
-                        if (\\$$request_uri !~* ^\\/rabbitmq\\/.*) {\\n
-                            set \\$$is_rabbitmq \\\"\\$${is_rabbitmq}B\\\";\\n
-                        }\\n
-                        if (\\$$is_rabbitmq = AB) { \\n
-                            rewrite ^\\/*(.*) \\/rabbitmq\\/\\$$1 permanent;\\n
-                        }\\n
                         location \\/airflow\\/ {\\n
                             proxy_pass http:\\/\\/webserver:8080;\\n
                             proxy_set_header Host \\$$http_host;\\n
@@ -250,10 +241,6 @@ services:
                             proxy_set_header Upgrade \\$$http_upgrade; \\n
                             proxy_set_header Connection \\\"upgrade\\\"; \\n
                             proxy_set_header X-Forwarded-Proto \\$$scheme; \\n
-                        }\\n
-                        location ^~ \\/rabbitmq\\/ {\\n
-                            proxy_pass http:\\/\\/rabbitmq:15672\\/;\\n
-                            proxy_redirect off;\\n
                         }\\n
                         location ^~ \\/grafana\\/ {\\n
                             proxy_pass http:\\/\\/grafana:3000\\/;\\n

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -32,6 +32,7 @@ services:
             - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit heartbeat 600 consumer_timeout 2592000000
         volumes:
             - /var/lib/rabbitmq:/var/lib/rabbitmq
+            - /enabled_plugins:/etc/rabbitmq/enabled_plugins
         ports:
             - "5672:5672"
             - "15672:15672"

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -20,7 +20,10 @@ x-airflow-common:
         - /var/run/docker.sock:/var/run/docker.sock
         - /tmp:/tmp
 
-
+volumes:
+    prometheus-storage:
+    grafana-storage:
+    redis-storage:
 
 services:
     rabbitmq:
@@ -79,6 +82,8 @@ services:
 
     prometheus:
         image: ranlu/prometheus
+        volumes:
+            - prometheus-storage:/prometheus
 
     grafana:
         image: ranlu/grafana
@@ -91,11 +96,16 @@ services:
             POSTGRES_USER:
             POSTGRES_PASSWORD:
             POSTGRES_DB:
+        volumes:
+            - grafana-storage:/var/lib/grafana
 
     redis:
         image: redis:7-alpine
+        command: redis-server --save 60 1
         ports:
             - "6379:6379"
+        volumes:
+            - redis-storage:/data
         healthcheck:
             test: ["CMD", "redis-cli", "ping"]
             interval: 5s


### PR DESCRIPTION
Update various services used by seuron:
1. Updated rabbitmq from 3.8 to 3.10 branch
2. Update nginx from 1.13.5 to 1.23.0
3. Change the redis image tag from latest to 7, to prevent unexpected major version bump.
4. Add persistent storage to prometheus/grafana/redis, so the data can be recovered after crash or reboot.
5. Enable prometheus plugin for rabbitmq, so we can visualize the metrics in grafana
6. Removed route for rabbitmq web interface in nginx.