### PR TITLE
feat: synaptor configs use JSON

### DIFF
--- a/dags/param_default.py
+++ b/dags/param_default.py
@@ -51,10 +51,9 @@ inference_param_default = {
     "BBOX": [7168, 20480, 1500, 8608, 21920, 1764],
 }
 
-default_synaptor_param = """
-[Workflow]
-maxclustersize = 1
-"""
+default_synaptor_param = {
+    "Workflow": dict(maxclustersize=1)
+}
 
 default_args = {
     'owner': 'seuronbot',

--- a/dags/synaptor_dags.py
+++ b/dags/synaptor_dags.py
@@ -1,6 +1,5 @@
 """DAG definition for synaptor workflows."""
 from datetime import datetime
-from configparser import ConfigParser
 
 from airflow import DAG
 from airflow.models import Variable
@@ -14,16 +13,10 @@ from synaptor_ops import synaptor_op, wait_op, generate_op
 # Processing parameters
 # We need to set a default so any airflow container can parse the dag before we
 # pass in a configuration file
-
-try:
-    param = Variable.get("synaptor_param", default_synaptor_param)
-    cp = ConfigParser()
-    cp.read_string(param)
-    MAX_CLUSTER_SIZE = cp.getint("Workflow", "maxclustersize")
-
-except:  # not sure why this doesn't work sometimes
-    MAX_CLUSTER_SIZE = 1
-
+param = Variable.get(
+    "synaptor_param.json", default_synaptor_param, deserialize_json=True
+)
+MAX_CLUSTER_SIZE = int(param.get("Workflow", {}).get("maxclustersize", 1))
 
 default_args = {
     "owner": "seuronbot",

--- a/dags/synaptor_ops.py
+++ b/dags/synaptor_ops.py
@@ -53,11 +53,11 @@ def drain_op(
 
 def manager_op(dag: DAG, synaptor_task_name: str, queue: str = "manager") -> Operator:
     """An operator fn for running synaptor tasks on the airflow node."""
-    config_path = os.path.join(MOUNT_POINT, "synaptor_param")
+    config_path = os.path.join(MOUNT_POINT, "synaptor_param.json")
     command = f"{synaptor_task_name} {config_path}"
 
     # these variables will be mounted in the containers
-    variables = ["synaptor_param"]
+    variables = ["synaptor_param.json"]
 
     return worker_op(
         variables=variables,
@@ -86,7 +86,7 @@ def generate_op(
     from airflow import configuration as conf
 
     broker_url = conf.get("celery", "broker_url")
-    config_path = os.path.join(MOUNT_POINT, "synaptor_param")
+    config_path = os.path.join(MOUNT_POINT, "synaptor_param.json")
 
     command = (
         f"generate {taskname} {config_path}"
@@ -95,7 +95,7 @@ def generate_op(
     )
 
     # these variables will be mounted in the containers
-    variables = add_secrets_if_defined(["synaptor_param"])
+    variables = add_secrets_if_defined(["synaptor_param.json"])
 
     task_id = f"generate_{taskname}" if tag is None else f"generate_{taskname}_{tag}"
 
@@ -126,7 +126,7 @@ def synaptor_op(
     from airflow import configuration as conf
 
     broker_url = conf.get("celery", "broker_url")
-    config_path = os.path.join(MOUNT_POINT, "synaptor_param")
+    config_path = os.path.join(MOUNT_POINT, "synaptor_param.json")
 
     command = (
         f"worker --configfilename {config_path}"
@@ -136,7 +136,7 @@ def synaptor_op(
     )
 
     # these variables will be mounted in the containers
-    variables = add_secrets_if_defined(["synaptor_param"])
+    variables = add_secrets_if_defined(["synaptor_param.json"])
 
     task_id = f"worker_{i}" if tag is None else f"worker_{tag}_{i}"
 

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -20,6 +20,7 @@ import time
 import logging
 from secrets import token_hex
 from datetime import datetime
+from configparser import ConfigParser
 import threading
 import queue
 import subprocess
@@ -301,15 +302,28 @@ def update_synaptor_params(msg):
     # Current file format is ini/toml, not json
     _, content = download_file(msg)
 
+    def config_to_json(content):
+        cp = ConfigParser()
+        cp.read_string(content)
+
+        return {
+            section: {
+                field: cp[section][field] for field in cp[section]
+            }
+            for section in cp
+        }
+
     if content is not None:  # download_file returns None if there's a problem
         if check_running():
             replyto(msg, "Busy right now")
             return
 
         replyto(msg, "Running synaptor sanity check. Please wait.")
-
         update_metadata(msg)
-        set_variable("synaptor_param", content)
+
+        param = config_to_json(content)
+
+        set_variable("synaptor_param.json", param, serialize_json=True)
         synaptor_sanity_check()
 
     else:


### PR DESCRIPTION
This commit converts the internal representation of synaptor parameters into a dictionary/JSON. This standardizes the representation for the redis integration @ranlu is building. A similar conversion can be done for corgie, and I'll add those changes once this is merged into main.

One complication with synaptor was that our docker machinery only mounts variables directly, and doesn't offer any way to format them first (e.g., mount a specific key). In this case, I just changed the synaptor configuration parsing to also support JSON. This largely simplified the code anyway, but it might be nice to flesh out other mounting functionality later if we run into similar problems again.