### PR TITLE
Airflow api cleanup

### DIFF
--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -89,10 +89,14 @@ def check_running():
     return run_in_executor(__check_running).result()
 
 
+def __run_dag(dag_id):
+    dbag = DagBag()
+    dbag.sync_to_db()
+    dag_run = trigger_dag(dag_id)
 
 
 def run_dag(dag_id):
-    return run_in_executor(trigger_dag, dag_id).result()
+    return run_in_executor(__run_dag, dag_id)
 
 
 def get_variable(key, deserialize_json=False):

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -8,7 +8,7 @@ from airflow.models import (DagBag, DagRun, Variable, Connection, DAG)
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.api.common.mark_tasks import set_dag_run_state_to_success
 from airflow.api.common.trigger_dag import trigger_dag
-from airflow.utils.state import State
+from airflow.utils.state import State, DagRunState
 from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
@@ -67,9 +67,10 @@ def update_user_info(userid):
 
 def check_running():
     """Checks whether the DAGs within the seuron_dags list (above) is running."""
-    for d in seuron_dags:
-        state, exec_date = dag_state(d)
-        if state == "running":
+    runs = DagRun.find(state=DagRunState.RUNNING)
+
+    for r in runs:
+        if r.dag_id in seuron_dags:
             return True
 
     return False

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -103,7 +103,7 @@ def set_variable(key, value, serialize_json=False):
     Variable.set(key, value, serialize_json=serialize_json)
 
 
-def __dag_state(dag_id):
+def __latest_dagrun_state(dag_id):
     print("check dag states")
     dagbag = DagBag()
     if dag_id not in dagbag.dags:
@@ -118,5 +118,5 @@ def __dag_state(dag_id):
         latest_run = d.get_dagrun(execution_date=execution_date)
         return latest_run.state
 
-def dag_state(dag_id):
-    return run_in_executor(__dag_state, dag_id).result()
+def latest_dagrun_state(dag_id):
+    return run_in_executor(__latest_dagrun_state, dag_id).result()

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -1,13 +1,10 @@
 import time
 import json
-from bot_info import workerid, slack_notification_channel
-
-import pendulum
 import functools
 import concurrent.futures
 
 from airflow import settings
-from airflow.models import (DagBag, DagRun, Variable, Connection, DAG)
+from airflow.models import DagBag, Variable, Connection
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.api.common.mark_tasks import set_dag_run_state_to_success
 from airflow.api.common.trigger_dag import trigger_dag
@@ -15,6 +12,8 @@ from airflow.utils.state import State, DagRunState
 from airflow.utils import timezone
 
 from sqlalchemy.orm import exc
+
+from bot_info import workerid, slack_notification_channel
 
 seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment"]
 

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -100,12 +100,10 @@ def dag_state(dag_id):
         print("=========== dag_id does not exist ============")
         return "null", "null"
 
-    runs = DagRun.find(dag_id=dag_id)
-    for r in runs:
-        print(r.id, r.run_id, r.state, r.dag_id)
-    if len(runs) == 0:
+    d = dagbag.dags[dag_id]
+    execution_date = d.get_latest_execution_date()
+    if not execution_date:
         return "unknown", "unknown"
     else:
-        latest_run = runs[-1]
-        #start_date = ((latest_run.start_date or '') and latest_run.start_date.isoformat())
+        latest_run = d.get_dagrun(execution_date=execution_date)
         return latest_run.state, latest_run.execution_date

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -22,12 +22,13 @@ def latest_task():
 
 def mark_dags_success():
     dagbag = DagBag()
-    for d in seuron_dags:
-        if d in dagbag.dags:
-            state, exec_date = dag_state(d)
-            if state == "running":
-                dag = dagbag.dags[d]
-                set_dag_run_state_to_success(dag=dag, execution_date=dag.latest_execution_date, commit=True)
+    runs = DagRun.find(state=DagRunState.RUNNING)
+
+    for r in runs:
+        d = r.dag_id
+        if d in seuron_dags:
+            dag = dagbag.dags[d]
+            set_dag_run_state_to_success(dag=dag, execution_date=dag.get_latest_execution_date(), commit=True)
 
 
 def update_slack_connection(payload, token):

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -20,8 +20,7 @@ seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chun
 
 def run_in_executor(f, /, *args, **kwargs):
     with concurrent.futures.ProcessPoolExecutor() as executor:
-        future = executor.submit(functools.partial(f, *args, **kwargs))
-        return future
+        return executor.submit(functools.partial(f, *args, **kwargs)).result()
 
 
 def __mark_dags_success():
@@ -36,7 +35,7 @@ def __mark_dags_success():
 
 
 def mark_dags_success():
-    return run_in_executor(__mark_dags_success).result()
+    return run_in_executor(__mark_dags_success)
 
 
 def update_slack_connection(payload, token):
@@ -86,7 +85,7 @@ def __check_running():
 
 
 def check_running():
-    return run_in_executor(__check_running).result()
+    return run_in_executor(__check_running)
 
 
 def __run_dag(dag_id):
@@ -96,7 +95,7 @@ def __run_dag(dag_id):
 
 
 def run_dag(dag_id, wait_for_completion=False):
-    dagrun = run_in_executor(__run_dag, dag_id).result()
+    dagrun = run_in_executor(__run_dag, dag_id)
     if wait_for_completion:
         while True:
             time.sleep(60)
@@ -132,4 +131,4 @@ def __latest_dagrun_state(dag_id):
         return latest_run.state
 
 def latest_dagrun_state(dag_id):
-    return run_in_executor(__latest_dagrun_state, dag_id).result()
+    return run_in_executor(__latest_dagrun_state, dag_id)

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -74,35 +74,8 @@ def check_running():
     return False
 
 
-def trigger_or_clear_dag(dag_id):
-    state, exec_date = dag_state(dag_id)
-    if state == "success" or state == "unknown":
-        run_dag(dag_id)
-        return True
-    elif state == "failed":
-        print(exec_date)
-        dagbag = DagBag()
-        dags = [dagbag.dags[dag_id]]
-        DAG.clear_dags(dags, start_date=exec_date)
-        return True
-    else:
-        print("do not understand {} state".format(state))
-        return False
 
 
-def sanity_check():
-    dag_id = "sanity_check"
-    trigger_or_clear_dag(dag_id)
-
-
-def synaptor_sanity_check():
-    """Runs the synaptor sanity check DAG."""
-    trigger_or_clear_dag("synaptor_sanity_check")
-
-
-def chunkflow_set_env():
-    dag_id = "chunkflow_generator"
-    trigger_or_clear_dag(dag_id)
 
 
 def run_dag(dag_id):
@@ -129,83 +102,6 @@ def run_dag(dag_id):
     session.add(dr)
     session.commit()
     session.close()
-
-
-def run_igneous_tasks():
-    dag_id = "igneous"
-
-    if check_running():
-        return False
-
-    run_dag(dag_id)
-    return True
-
-
-def run_custom_tasks(task_type):
-    dag_id = f"custom-{task_type}"
-
-    if check_running():
-        return False
-
-    run_dag(dag_id)
-    return True
-
-
-def run_segmentation():
-    dag_id = "segmentation"
-
-    if check_running():
-        return False
-
-    run_dag(dag_id)
-    return True
-
-
-def run_inference():
-    dag_id = "chunkflow_worker"
-
-    if check_running():
-        return False
-
-    run_dag(dag_id)
-    return True
-
-
-def run_contact_surface():
-    dag_id = "contact_surface"
-
-    if check_running():
-        return False
-
-    run_dag(dag_id)
-    return True
-
-
-def run_synaptor_file_seg():
-    """Runs the synaptor file segmentation DAG."""
-    if check_running():
-        return False
-
-    run_dag("synaptor_file_seg")
-    return True
-
-
-def run_synaptor_db_seg():
-    """Runs the synaptor database segmentation DAG."""
-    if check_running():
-        return False
-
-    run_dag("synaptor_db_seg")
-    return True
-
-
-def run_synaptor_assignment():
-    """Runs the synaptor assignment DAG."""
-    if check_running():
-        return False
-
-    run_dag("synaptor_assignment")
-    return True
 
 
 def get_variable(key, deserialize_json=False):

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -108,15 +108,15 @@ def __dag_state(dag_id):
     dagbag = DagBag()
     if dag_id not in dagbag.dags:
         print("=========== dag_id does not exist ============")
-        return "null", "null"
+        return "null"
 
     d = dagbag.dags[dag_id]
     execution_date = d.get_latest_execution_date()
     if not execution_date:
-        return "unknown", "unknown"
+        return "unknown"
     else:
         latest_run = d.get_dagrun(execution_date=execution_date)
-        return latest_run.state, latest_run.execution_date
+        return latest_run.state
 
 def dag_state(dag_id):
     return run_in_executor(__dag_state, dag_id).result()

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -7,6 +7,7 @@ from airflow import settings
 from airflow.models import (DagBag, DagRun, Variable, Connection, DAG)
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.api.common.mark_tasks import set_dag_run_state_to_success
+from airflow.api.common.trigger_dag import trigger_dag
 from airflow.utils.state import State
 from airflow.utils import timezone
 
@@ -79,29 +80,7 @@ def check_running():
 
 
 def run_dag(dag_id):
-    print("run dag {}".format(dag_id))
-    execution_date = timezone.utcnow()
-    run_id = 'trig__' + execution_date.isoformat()
-    dbag = DagBag()
-    dbag.sync_to_db()
-    trigger_dag = dbag.get_dag(dag_id)
-    session = settings.Session()
-
-    dr = trigger_dag.create_dagrun(
-        run_type=DagRunType.MANUAL,
-        run_id=run_id,
-        execution_date=execution_date,
-        state=State.QUEUED,
-        conf=None,
-        data_interval=trigger_dag.timetable.infer_manual_data_interval(
-            run_after=pendulum.instance(execution_date)
-        ),
-        dag_hash=dbag.dags_hash.get(dag_id),
-        external_trigger=True)
-    print("Creating DagRun {}".format(dr))
-    session.add(dr)
-    session.commit()
-    session.close()
+    trigger_dag(dag_id)
 
 
 def get_variable(key, deserialize_json=False):

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -16,8 +16,6 @@ from sqlalchemy.orm import exc
 seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment"]
 
 
-def latest_task():
-    state, exec_date = dag_state("sanity_check")
 
 
 def mark_dags_success():

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -259,7 +259,7 @@ def on_cancel_run(msg):
                       description="Create segmentation with updated parameters")
 def on_run_segmentations(msg):
     global param_updated
-    state, _ = dag_state("sanity_check")
+    state = dag_state("sanity_check")
     if param_updated != 'seg_run':
         replyto(msg, "You have to update the parameters before starting the segmentation")
     elif state != "success":
@@ -277,7 +277,7 @@ def on_run_segmentations(msg):
                       description="Inference with updated parameters")
 def on_run_inferences(msg):
     global param_updated
-    state, _ = dag_state("chunkflow_generator")
+    state = dag_state("chunkflow_generator")
     if param_updated != 'inf_run':
         replyto(msg, "You have to update the parameters before starting the inference")
     elif state != "success":
@@ -353,7 +353,7 @@ def on_redeploy_docker_stack(msg):
                       description="Extract the contact surfaces between segments")
 def on_extract_contact_surfaces(msg):
     global param_updated
-    state, _ = dag_state("sanity_check")
+    state = dag_state("sanity_check")
     if state != "success":
         replyto(msg, "Sanity check failed, try again")
     else:
@@ -605,12 +605,12 @@ def handle_batch(q_payload, q_cmd):
                     set_variable('param', param, serialize_json=True)
                     run_dag("sanity_check")
                     wait_for_airflow()
-                    state, _ = dag_state("sanity_check")
+                    state = dag_state("sanity_check")
                 elif current_task == "inf_run":
                     set_variable('inference_param', param, serialize_json=True)
                     run_dag("chunkflow_generator")
                     wait_for_airflow()
-                    state, _ = dag_state("chunkflow_generator")
+                    state = dag_state("chunkflow_generator")
 
                 if state != "success":
                     replyto(msg, "*Sanity check failed, abort!*")
@@ -621,11 +621,11 @@ def handle_batch(q_payload, q_cmd):
             if current_task == "seg_run":
                 run_dag('segmentation')
                 wait_for_airflow()
-                state, _ = dag_state("segmentation")
+                state = dag_state("segmentation")
             elif current_task == "inf_run":
                 run_dag("chunkflow_worker")
                 wait_for_airflow()
-                state, _ = dag_state("chunkflow_worker")
+                state = dag_state("chunkflow_worker")
 
             if state != "success":
                 replyto(msg, "*Bach job failed, abort!*")

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -183,8 +183,8 @@ def update_inference_param(msg):
         supply_default_param(json_obj)
         replyto(msg, "Running chunkflow setup_env, please wait")
         set_variable('inference_param', json_obj, serialize_json=True)
-        run_dag("chunkflow_generator")
         param_updated = "inf_run"
+        run_dag("chunkflow_generator")
 
     return
 
@@ -387,8 +387,8 @@ def update_segmentation_param(msg, advanced=False):
         replyto(msg, "Running sanity check, please wait")
         set_variable('param', json_obj, serialize_json=True)
         time.sleep(30)
-        run_dag("sanity_check")
         param_updated = "seg_run"
+        run_dag("sanity_check")
 
     return
 

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -386,7 +386,6 @@ def update_segmentation_param(msg, advanced=False):
         supply_default_param(json_obj)
         replyto(msg, "Running sanity check, please wait")
         set_variable('param', json_obj, serialize_json=True)
-        time.sleep(30)
         param_updated = "seg_run"
         run_dag("sanity_check")
 


### PR DESCRIPTION
Run the expensive airflow calls with ProcessPoolExecutor to eliminate the warning about using signals in threads. Also simplify the code in various places. @nicholasturner1, the synaptor changes should be trivial, I guess it is safer you review/test it.