### PR TITLE
Compute metrics

### DIFF
--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -1,5 +1,5 @@
 from common import GlobalComputeUrl, ZonalComputeUrl, GenerateBootDisk, GenerateNetworkInterface, GenerateAirflowVar
-from common import INSTALL_DOCKER_CMD, INSTALL_NVIDIA_DOCKER_CMD, DOCKER_CMD, CELERY_CMD, PARALLEL_CMD
+from common import INSTALL_DOCKER_CMD, INSTALL_NVIDIA_DOCKER_CMD, INSTALL_GPU_MONITORING, DOCKER_CMD, CELERY_CMD, PARALLEL_CMD
 
 
 GPU_TYPES = ['gpu', 'custom-gpu', 'synaptor-gpu']
@@ -27,6 +27,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -
 
     if use_gpu:
         startup_script += INSTALL_NVIDIA_DOCKER_CMD
+        startup_script += INSTALL_GPU_MONITORING
 
     startup_script += f'''
 {GenerateEnvironVar(context, env_variables)}

--- a/dags/chunkflow_dag.py
+++ b/dags/chunkflow_dag.py
@@ -10,7 +10,7 @@ from igneous_and_cloudvolume import check_queue, cv_has_data, cv_scale_with_data
 
 from slack_message import slack_message, task_retry_alert, task_failure_alert
 
-from helper_ops import slack_message_op, mark_done_op, scale_up_cluster_op, scale_down_cluster_op, setup_redis_op
+from helper_ops import slack_message_op, mark_done_op, scale_up_cluster_op, scale_down_cluster_op, setup_redis_op, collect_metrics_op
 
 from cloudvolume import CloudVolume
 from cloudvolume.lib import Bbox
@@ -513,7 +513,7 @@ queue = 'gpu'
 for i in range(min(param.get("TASK_NUM", 1), total_gpus)):
     workers.append(inference_op(dag_worker, param, queue, i))
 
-scale_up_cluster_task >> workers >> scale_down_cluster_task
+collect_metrics_op(dag_worker) >> scale_up_cluster_task >> workers >> scale_down_cluster_task
 
 setup_redis_task >> sanity_check_task >> image_parameters >> drain_tasks >> set_env_task >> process_output_task
 

--- a/dags/compute_metrics_dag.py
+++ b/dags/compute_metrics_dag.py
@@ -1,0 +1,74 @@
+import pendulum
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+
+metrics_default_args = {
+    'owner': 'seuronbot',
+    'depends_on_past': False,
+    'start_date': pendulum.datetime(2019, 2, 8),
+    'catchup': False,
+    'retries': 3,
+}
+
+def format_uptime(dt):
+    for attr in ["weeks", "days", "hours", "minutes", "seconds"]:
+        if getattr(dt, attr) > 0:
+            return f'{getattr(dt, "total_"+attr)():.2f} instance-{attr}'
+
+
+with DAG("compute_metrics",
+        default_args=metrics_default_args,
+        schedule_interval=None,
+        tags=['maintenance']) as dag:
+
+    def resource_summary(dag_run):
+        import humanize
+        from time import sleep
+        from airflow.models.dagrun import DagRun
+        from airflow.utils.state import DagRunState
+        from slack_message import slack_message
+        from google_api_helper import collect_resource_metrics
+        conf = dag_run.conf
+        target_dag_id = conf["dag_id"]
+        target_run_id = conf["run_id"]
+        runs = DagRun.find(dag_id=target_dag_id, run_id=target_run_id)
+
+        if not runs:
+            slack_message("Cannot find the target dag run")
+            return
+
+        target_dag_run = runs[0]
+
+        while target_dag_run.state == DagRunState.RUNNING:
+            sleep(60)
+            target_dag_run.refresh_from_db()
+
+        start_time = target_dag_run.logical_date
+        end_time = target_dag_run.end_date
+
+        delay = 240 - (pendulum.now() - end_time).seconds
+
+        if delay > 0:
+            slack_message(f"Sleep {delay} seconds before collecting metrics")
+            sleep(delay)
+
+
+        messages = []
+        resources = collect_resource_metrics(start_time, end_time)
+        for ig in resources:
+            if resources[ig]:
+                if "gpu_utilization" in resources[ig]:
+                    messages += [f"`{ig}`: `{format_uptime(resources[ig]['uptime'])}` (`{resources[ig]['gpu_utilization']:.2f}%` GPU utilization, `{resources[ig]['cpu_utilization']:.2f}%` CPU utilization), `{humanize.naturalsize(resources[ig]['received_bytes'])}` received, `{humanize.naturalsize(resources[ig]['sent_bytes'])}` sent"]
+                else:
+                    messages += [f"`{ig}`: `{format_uptime(resources[ig]['uptime'])}` (`{resources[ig]['cpu_utilization']:.2f}%` CPU utilization), `{humanize.naturalsize(resources[ig]['received_bytes'])}` received, `{humanize.naturalsize(resources[ig]['sent_bytes'])}` sent"]
+
+        if messages:
+            slack_message("\n".join([f"*Compute resources used by* `{target_dag_id}` *in {pendulum.period(start_time, end_time).in_words()}*:"] + messages), broadcast=True)
+
+    res_op = PythonOperator(
+                task_id='resource_summary',
+                python_callable=resource_summary,
+                priority_weight=1000,
+                queue="manager",
+            )

--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -204,7 +204,7 @@ def collect_resource_metrics(start_time, end_time):
             "alignment_period": {"seconds": alignment_period},
             "per_series_aligner": monitoring_v3.Aggregation.Aligner.ALIGN_SUM,
             "cross_series_reducer": monitoring_v3.Aggregation.Reducer.REDUCE_SUM,
-            "group_by_fields": ["metadata.system_labels.instance_group"],
+            "group_by_fields": ["metadata.user_labels.vmrole", "metadata.user_labels.location", "metadata.system_labels.instance_group"],
         }
     )
 
@@ -214,7 +214,7 @@ def collect_resource_metrics(start_time, end_time):
             "alignment_period": {"seconds": alignment_period},
             "per_series_aligner": monitoring_v3.Aggregation.Aligner.ALIGN_MEAN,
             "cross_series_reducer": monitoring_v3.Aggregation.Reducer.REDUCE_SUM,
-            "group_by_fields": ["metadata.system_labels.instance_group"],
+            "group_by_fields": ["metadata.user_labels.vmrole", "metadata.user_labels.location", "metadata.system_labels.instance_group"],
         }
     )
 

--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -174,3 +174,86 @@ def reduce_instance_group_size(key, size):
         real_size = resize_instance_group(project_id, cluster_info[key], size)
         slack_message(":arrow_down: Scale down cluster {} to {} instances, sleep for one minute to let it stablize".format(key, real_size))
         sleep(60)
+
+def collect_resource_metrics(start_time, end_time):
+    import pendulum
+    from google.cloud import monitoring_v3
+
+    project_id = get_project_id()
+    cluster_info = json.loads(BaseHook.get_connection("InstanceGroups").extra)
+
+    resources = {}
+
+    for k in cluster_info:
+        resources |= {ig['name'] : {} for ig in cluster_info[k]}
+
+    alignment_period = 60
+
+    client = monitoring_v3.MetricServiceClient()
+    project_name = f"projects/{project_id}"
+
+    interval = monitoring_v3.TimeInterval(
+        {
+            "end_time": {"seconds": int(end_time.timestamp()), "nanos": 0},
+            "start_time": {"seconds": int(start_time.timestamp()), "nanos": 0},
+        }
+    )
+    aggregation_sum = monitoring_v3.Aggregation(
+        {
+            # Use SUM for DELTA metrics
+            "alignment_period": {"seconds": alignment_period},
+            "per_series_aligner": monitoring_v3.Aggregation.Aligner.ALIGN_SUM,
+            "cross_series_reducer": monitoring_v3.Aggregation.Reducer.REDUCE_SUM,
+            "group_by_fields": ["metadata.system_labels.instance_group"],
+        }
+    )
+
+    aggregation_mean = monitoring_v3.Aggregation(
+        {
+            # SUM over series so we can average by uptime
+            "alignment_period": {"seconds": alignment_period},
+            "per_series_aligner": monitoring_v3.Aggregation.Aligner.ALIGN_MEAN,
+            "cross_series_reducer": monitoring_v3.Aggregation.Reducer.REDUCE_SUM,
+            "group_by_fields": ["metadata.system_labels.instance_group"],
+        }
+    )
+
+    def query_metric(metric, aggregation):
+        return client.list_time_series(
+           request={
+               "name": project_name,
+               "filter": f'metric.type = "{metric}"',
+               "interval": interval,
+               "view": monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+               "aggregation": aggregation,
+           }
+        )
+
+    for result in query_metric("compute.googleapis.com/instance/uptime", aggregation_sum):
+        group_name = result.metadata.system_labels.fields['instance_group'].string_value
+        if group_name in resources:
+            resources[group_name]["uptime"] = pendulum.duration(seconds=sum(p.value.double_value for p in result.points))
+
+    for result in query_metric("compute.googleapis.com/instance/cpu/usage_time", aggregation_sum):
+        group_name = result.metadata.system_labels.fields['instance_group'].string_value
+        if group_name in resources:
+            resources[group_name]["cputime"] = pendulum.duration(seconds=sum(p.value.double_value for p in result.points))
+            resources[group_name]["cpu_utilization"] = resources[group_name]["cputime"].total_seconds()/resources[group_name]["uptime"].total_seconds()*100
+
+    for result in query_metric("compute.googleapis.com/instance/network/received_bytes_count", aggregation_sum):
+        group_name = result.metadata.system_labels.fields['instance_group'].string_value
+        if group_name in resources:
+            resources[group_name]["received_bytes"] = sum(p.value.int64_value for p in result.points)
+
+    for result in query_metric("compute.googleapis.com/instance/network/sent_bytes_count", aggregation_sum):
+        group_name = result.metadata.system_labels.fields['instance_group'].string_value
+        if group_name in resources:
+            resources[group_name]["sent_bytes"] = sum(p.value.int64_value for p in result.points)
+
+    for result in query_metric("custom.googleapis.com/instance/gpu/utilization", aggregation_mean):
+        group_name = result.metadata.system_labels.fields['instance_group'].string_value
+        if group_name in resources:
+            resources[group_name]["gputime"] = pendulum.duration(seconds=sum(p.value.double_value*alignment_period/100 for p in result.points))
+            resources[group_name]["gpu_utilization"] = resources[group_name]["gputime"].total_seconds()/resources[group_name]["uptime"].total_seconds()*100
+
+    return resources

--- a/dags/helper_ops.py
+++ b/dags/helper_ops.py
@@ -50,6 +50,9 @@ def reset_flags(param):
         Variable.set("agg_done", "yes")
     else:
         Variable.set("agg_done", "no")
+
+    Variable.set("pp_done", "no")
+
     try:
         target_sizes = Variable.get("cluster_target_size", deserialize_json=True)
         for key in target_sizes:

--- a/dags/helper_ops.py
+++ b/dags/helper_ops.py
@@ -1,11 +1,12 @@
 from airflow.operators.python import PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.weight_rule import WeightRule
 from airflow.models import Variable
 from time import sleep
 from slack_message import slack_message
 from param_default import default_args
-from google_api_helper import ramp_up_cluster, ramp_down_cluster, reset_cluster
+from google_api_helper import ramp_up_cluster, ramp_down_cluster, reset_cluster, collect_resource_metrics
 
 def slack_message_op(dag, tid, msg):
     return PythonOperator(
@@ -167,4 +168,19 @@ def reset_cluster_op(dag, stage, key, initial_size, queue):
         trigger_rule="all_success",
         queue=queue,
         dag=dag
+    )
+
+
+def collect_metrics_op(dag):
+    return TriggerDagRunOperator(
+        task_id="trigger_compute_metrics",
+        trigger_dag_id="compute_metrics",
+        conf={
+            "dag_id": "{{ dag_run.dag_id }}",
+            "run_id": "{{ dag_run.run_id }}",
+        },
+        weight_rule=WeightRule.ABSOLUTE,
+        priority_weight=1000,
+        dag=dag,
+        queue = "manager"
     )

--- a/dags/igneous_dag.py
+++ b/dags/igneous_dag.py
@@ -4,7 +4,7 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.weight_rule import WeightRule
 from datetime import datetime
 from slack_message import task_failure_alert
-from helper_ops import scale_down_cluster_op
+from helper_ops import scale_down_cluster_op, collect_metrics_op
 
 igneous_default_args = {
     'owner': 'seuronbot',
@@ -28,7 +28,7 @@ submit_igneous_tasks = PythonOperator(
     dag=dag_igneous
 )
 
-submit_igneous_tasks >> scaling_igneous_finish
+collect_metrics_op(dag_igneous) >> submit_igneous_tasks >> scaling_igneous_finish
 
 
 dag_custom_cpu = DAG("custom-cpu", default_args=igneous_default_args, schedule_interval=None, tags=['custom tasks'])
@@ -45,7 +45,7 @@ submit_custom_cpu_tasks = PythonOperator(
     dag=dag_custom_cpu
 )
 
-submit_custom_cpu_tasks >> scaling_custom_cpu_finish
+collect_metrics_op(dag_custom_cpu) >> submit_custom_cpu_tasks >> scaling_custom_cpu_finish
 
 
 dag_custom_gpu = DAG("custom-gpu", default_args=igneous_default_args, schedule_interval=None, tags=['custom tasks'])
@@ -62,4 +62,4 @@ submit_custom_gpu_tasks = PythonOperator(
     dag=dag_custom_gpu
 )
 
-submit_custom_gpu_tasks >> scaling_custom_gpu_finish
+collect_metrics_op(dag_custom_gpu) >> submit_custom_gpu_tasks >> scaling_custom_gpu_finish

--- a/dags/segmentation_dags.py
+++ b/dags/segmentation_dags.py
@@ -114,9 +114,12 @@ dag["agg"] = DAG("agglomeration", default_args=default_args, schedule_interval=N
 
 dag["cs"] = DAG("contact_surface", default_args=default_args, schedule_interval=None, tags=['segmentation'])
 
+dag["pp"] = DAG("postprocess", default_args=default_args, schedule_interval=None, tags=['segmentation'])
+
 dag_ws = dag["ws"]
 dag_agg = dag["agg"]
 dag_cs = dag["cs"]
+dag_pp= dag["pp"]
 
 param = Variable.get("param", deserialize_json=True)
 image = param["WORKER_IMAGE"]
@@ -538,6 +541,18 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
 
     mark_done["agg"] = mark_done_op(dag["agg"], "agg_done")
 
+    triggers["pp"] = TriggerDagRunOperator(
+        task_id="trigger_pp",
+        trigger_dag_id="postprocess",
+        queue="manager",
+        dag=dag_manager
+    )
+
+    wait["pp"] = wait_op(dag_manager, "pp_done")
+
+    mark_done["pp"] = mark_done_op(dag["pp"], "pp_done")
+
+
     check_seg = PythonOperator(
         task_id="Check_Segmentation",
         python_callable=process_infos,
@@ -629,14 +644,15 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
         slack_ops['agg']['remap'] >> comp_seg_task >> mark_done['agg']
 
 
-    igneous_tasks = create_igneous_ops(param, dag_manager)
+    igneous_tasks = create_igneous_ops(param, dag_pp)
+    igneous_tasks[-1] >> mark_done['pp']
 
     scaling_igneous_finish = scale_down_cluster_op(dag_manager, "igneous_finish", "igneous", 0, "cluster")
 
-    starting_op >> reset_flags >> triggers["ws"] >> wait["ws"] >> triggers["agg"] >> wait["agg"] >> igneous_tasks[0]
-    igneous_tasks[-1] >> ending_op
+    starting_op >> reset_flags >> triggers["ws"] >> wait["ws"] >> triggers["agg"] >> wait["agg"] >> triggers["pp"] >> wait["pp"]
+    wait["pp"] >> ending_op
     reset_flags >> scaling_global_start
-    igneous_tasks[-1]>> scaling_igneous_finish
+    wait["pp"] >> scaling_igneous_finish
     wait["agg"] >> scaling_global_finish
 
     nglink_task = PythonOperator(
@@ -648,7 +664,8 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
         dag=dag_manager,
         queue = "manager"
     )
-    igneous_tasks[-1] >> nglink_task >> ending_op
+    wait["pp"] >> nglink_task >> ending_op
+
     if "GT_PATH" in param:
         evaluation_task = PythonOperator(
             task_id = "Evaluate_Segmentation",
@@ -659,7 +676,7 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
             dag=dag_manager,
             queue = "manager"
         )
-        igneous_tasks[-1] >> evaluation_task >> ending_op
+        wait["pp"] >> evaluation_task
 
 
     if min(high_mip, top_mip) - batch_mip > 2:

--- a/dags/segmentation_dags.py
+++ b/dags/segmentation_dags.py
@@ -656,11 +656,10 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
 
     scaling_igneous_finish = scale_down_cluster_op(dag_manager, "igneous_finish", "igneous", 0, "cluster")
 
-    starting_op >> reset_flags >> triggers["ws"] >> wait["ws"] >> triggers["agg"] >> wait["agg"] >> triggers["pp"] >> wait["pp"]
+    starting_op >> reset_flags >> triggers["ws"] >> wait["ws"] >> triggers["agg"] >> wait["agg"] >> scaling_global_finish >> triggers["pp"] >> wait["pp"]
     wait["pp"] >> ending_op
     reset_flags >> scaling_global_start
     wait["pp"] >> scaling_igneous_finish
-    wait["agg"] >> scaling_global_finish
 
     nglink_task = PythonOperator(
         task_id = "Generate_neuroglancer_link",

--- a/dags/synaptor_dags.py
+++ b/dags/synaptor_dags.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from airflow import DAG
 from airflow.models import Variable
 
-from helper_ops import scale_up_cluster_op, scale_down_cluster_op
+from helper_ops import scale_up_cluster_op, scale_down_cluster_op, collect_metrics_op
 from param_default import default_synaptor_param
 from synaptor_ops import manager_op, drain_op
 from synaptor_ops import synaptor_op, wait_op, generate_op
@@ -84,7 +84,7 @@ wait_remap = wait_op(fileseg_dag, "remap")
 
 # DEPENDENCIES
 # Drain old tasks before doing anything
-drain >> sanity_check >> init_cloudvols  # >> generate_ngl_link
+collect_metrics_op(fileseg_dag) >> drain >> sanity_check >> init_cloudvols  # >> generate_ngl_link
 
 # Worker dag
 (init_cloudvols >> scale_up_cluster >> workers >> scale_down_cluster)
@@ -162,7 +162,7 @@ wait_remap = wait_op(dbseg_dag, "remap")
 
 # DEPENDENCIES
 # Drain old tasks before doing anything
-drain >> sanity_check >> init_cloudvols >> init_db  # >> generate_ngl_link
+collect_metrics_op(dbseg_dag) >> drain >> sanity_check >> init_cloudvols >> init_db  # >> generate_ngl_link
 
 # Worker dag
 (init_db >> scale_up_cluster >> workers >> scale_down_cluster)
@@ -282,7 +282,7 @@ wait_remap = wait_op(assign_dag, "remap")
 
 # DEPENDENCIES
 # Drain old tasks before doing anything
-drain >> sanity_check >> init_cloudvols >> init_db  # >> generate_ngl_link
+collect_metrics_op(assign_dag) >> drain >> sanity_check >> init_cloudvols >> init_db  # >> generate_ngl_link
 
 # Worker dag
 (

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -168,7 +168,7 @@ services:
         <<: *airflow-common
         environment:
             <<: *airflow-common-env
-            AIRFLOW__CELERY__WORKER_CONCURRENCY: 2
+            AIRFLOW__CELERY__WORKER_CONCURRENCY: 3
         command: airflow celery worker --without-gossip --without-mingle -q manager
         deploy:
             restart_policy:

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import exc
 
 from bot_info import workerid, slack_notification_channel
 
-seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment"]
+seuron_dags = ['sanity_check', 'segmentation','watershed','agglomeration', "postprocess", 'chunkflow_worker', 'chunkflow_generator', 'contact_surface', "igneous", "custom-cpu", "custom-gpu", "synaptor_sanity_check", "synaptor_file_seg", "synaptor_db_seg", "synaptor_assignment"]
 
 
 def run_in_executor(f, /, *args, **kwargs):


### PR DESCRIPTION
Collect performance metrics of instance groups after a dag run. The implementation triggers the `comptue_metrics` dag at the beginning of the dag run we want to measure, it will wait until the dag run finishes and collect metrics after 240s delay. Also use https://github.com/GoogleCloudPlatform/compute-gpu-monitoring to collect GPU metrics

Right now the pr is made on top of the `slackbot_cleanup` branch, I will rebase it on top of main after we mrege https://github.com/seung-lab/seuron/pull/26