### PR TITLE
Heartbeat based instance management

### DIFF
--- a/dags/cluster_dag.py
+++ b/dags/cluster_dag.py
@@ -78,9 +78,6 @@ def cluster_control():
                     slack_message(":exclamation:Failed to get the {} cluster information from google.".format(key), notification=True)
                     continue
                 if num_tasks < total_size:
-                    if 10 < num_tasks < total_size//10:
-                        target_sizes[key] = total_size//10
-                        gapi.resize_instance_group(project_id, cluster_info[key], target_sizes[key])
                     continue
                 else:
                     if num_tasks < target_sizes[key]:

--- a/dags/cluster_dag.py
+++ b/dags/cluster_dag.py
@@ -81,7 +81,7 @@ def cluster_control():
                     continue
                 else:
                     if num_tasks < target_sizes[key]:
-                        target_sizes[key] = num_tasks
+                        target_sizes[key] = max(num_tasks, 1)
 
                 if total_target_size == 0 and num_tasks != 0:
                     gapi.resize_instance_group(project_id, cluster_info[key], 1)

--- a/dags/cluster_dag.py
+++ b/dags/cluster_dag.py
@@ -115,7 +115,7 @@ latest = LatestOnlyOperator(
     task_id='latest_only',
     priority_weight=100000,
     weight_rule=WeightRule.ABSOLUTE,
-    queue='manager',
+    queue='cluster',
     dag=dag)
 
 queue_sizes_task = PythonOperator(

--- a/dags/cluster_dag.py
+++ b/dags/cluster_dag.py
@@ -83,6 +83,10 @@ def cluster_control():
                     if num_tasks < target_sizes[key]:
                         target_sizes[key] = num_tasks
 
+                if total_target_size == 0 and num_tasks != 0:
+                    gapi.resize_instance_group(project_id, cluster_info[key], 1)
+                    continue
+
                 if (total_target_size - total_size) > 0.1 * total_target_size:
                     slack_message(":exclamation: cluster {} is still stabilizing, {} of {} instances created".format(key, total_size, total_target_size))
                     if (total_target_size > 0):

--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -24,6 +24,32 @@ def instance_group_info(project_id, instance_group):
     request = service.instanceGroups().get(project=project_id, zone=instance_group['zone'], instanceGroup=instance_group['name'])
     return request.execute()
 
+def list_managed_instances(project_id, instance_group):
+    service = discovery.build("compute", "v1")
+    page_token = None
+    instances = []
+    while True:
+        request = service.instanceGroupManagers().listManagedInstances(project=project_id, zone=instance_group["zone"], instanceGroupManager=instance_group["name"], pageToken=page_token)
+        ret = request.execute()
+        if not ret:
+            return instances
+        instances += [r["instance"] for r in ret['managedInstances']]
+        page_token = ret.get("nextPageToken", None)
+        if not page_token:
+            break
+
+    return instances
+
+def delete_instances(project_id, ig, instances):
+    request_body = {
+        "instances": instances,
+        "skipInstancesOnValidationError": True,
+    }
+    service = discovery.build('compute', 'v1')
+    request = service.instanceGroupManagers().deleteInstances(project=project_id, zone=ig["zone"], instanceGroupManager=ig["name"], body=request_body)
+    ret = request.execute()
+    print(ret)
+
 def get_cluster_target_size(project_id, instance_groups):
     total_size = 0
     for ig in instance_groups:

--- a/dags/heartbeat_dag.py
+++ b/dags/heartbeat_dag.py
@@ -30,7 +30,7 @@ default_args = {
     'retries': 0,
 }
 
-SCHEDULE_INTERVAL = '*/20 * * * *'
+SCHEDULE_INTERVAL = '2-59/5 * * * *'
 
 dag = DAG(
     dag_id=DAG_ID,

--- a/dags/heartbeat_dag.py
+++ b/dags/heartbeat_dag.py
@@ -119,14 +119,14 @@ def delete_dead_instances():
 latest = LatestOnlyOperator(
     task_id='latest_only',
     priority_weight=1000,
-    queue='manager',
+    queue='cluster',
     dag=dag)
 
 queue_sizes_task = PythonOperator(
     task_id="check_task_status",
     python_callable=get_num_task_instances,
     priority_weight=1000,
-    queue="manager",
+    queue="cluster",
     dag=dag)
 
 delete_dead_instances_task = PythonOperator(

--- a/dags/heartbeat_dag.py
+++ b/dags/heartbeat_dag.py
@@ -73,6 +73,49 @@ def get_num_task_instances(session):
 *{}* tasks running, *{}* tasks queued, *{}* tasks up for retry'''.format(running, queued, up_for_retry)
     slack_message(message, notification=True)
 
+def delete_dead_instances():
+    import os
+    import json
+    import redis
+    import humanize
+    from datetime import datetime
+    from airflow.models import Variable
+    from airflow.hooks.base_hook import BaseHook
+    import google_api_helper as gapi
+
+    project_id = gapi.get_project_id()
+    cluster_info = json.loads(BaseHook.get_connection("InstanceGroups").extra)
+    target_sizes = Variable.get("cluster_target_size", deserialize_json=True)
+
+    redis_host = os.environ['REDIS_SERVER']
+    timestamp = datetime.now().timestamp()
+    r = redis.Redis(redis_host)
+
+    for key in cluster_info:
+        if target_sizes.get(key, 0) == 0:
+            continue
+
+        for ig in cluster_info[key]:
+            instances = gapi.list_managed_instances(project_id, ig)
+
+            dead_instances = []
+            msg = ["The follow instances are deleted due to heartbeat timeout:"]
+            for instance_url in instances:
+                instance = instance_url.split("/")[-1]
+                ts = r.get(instance)
+                if not ts:
+                    r.set(instance, timestamp)
+                else:
+                    delta = timestamp - float(ts)
+                    if delta > 300:
+                        msg.append(f"{instance} has no heartbeat for {humanize.naturaldelta(delta)}")
+                        dead_instances.append(instance_url)
+
+            if dead_instances:
+                gapi.delete_instances(project_id, ig, dead_instances)
+                slack_message("\n".join(msg), notification=True)
+
+
 latest = LatestOnlyOperator(
     task_id='latest_only',
     priority_weight=1000,
@@ -86,4 +129,11 @@ queue_sizes_task = PythonOperator(
     queue="manager",
     dag=dag)
 
-latest.set_downstream(queue_sizes_task)
+delete_dead_instances_task = PythonOperator(
+    task_id="delete_dead_instances",
+    python_callable=delete_dead_instances,
+    priority_weight=1000,
+    queue="cluster",
+    dag=dag)
+
+latest >> queue_sizes_task >> delete_dead_instances_task

--- a/dags/heartbeat_dag.py
+++ b/dags/heartbeat_dag.py
@@ -97,6 +97,8 @@ def delete_dead_instances():
 
         for ig in cluster_info[key]:
             instances = gapi.list_managed_instances(project_id, ig)
+            if not instances:
+                continue
 
             dead_instances = []
             msg = ["The follow instances are deleted due to heartbeat timeout:"]
@@ -110,6 +112,9 @@ def delete_dead_instances():
                     if delta > 300:
                         msg.append(f"{instance} has no heartbeat for {humanize.naturaldelta(delta)}")
                         dead_instances.append(instance_url)
+
+            if len(instances) == len(dead_instances):
+                dead_instances = dead_instances[:-1]
 
             if dead_instances:
                 gapi.delete_instances(project_id, ig, dead_instances)

--- a/dags/helper_ops.py
+++ b/dags/helper_ops.py
@@ -74,6 +74,8 @@ def setup_redis(varname, dbname):
         param["REDIS_SERVER"] = os.environ['REDIS_SERVER']
         param["REDIS_DB"] = redis_databases[dbname]
         slack_message(f'*Use redis database {param["REDIS_DB"]} to track the progress of the run*')
+        r = redis.Redis(host=param["REDIS_SERVER"], db=redis_databases["SEURON"])
+        r.flushdb()
         if param.get("RESET_REDIS_DB", True):
             r = redis.Redis(host=param["REDIS_SERVER"], db=param["REDIS_DB"])
             r.flushdb()

--- a/dags/segmentation_dags.py
+++ b/dags/segmentation_dags.py
@@ -632,7 +632,10 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
 
     if cluster1_size >= 100:
         reset_cluster_after_ws = reset_cluster_op(dag['ws'], "ws", CLUSTER_1_CONN_ID, 20, "cluster")
-        slack_ops['ws']['remap'] >> reset_cluster_after_ws
+    else:
+        reset_cluster_after_ws = scale_up_cluster_op(dag['ws'], "reset_cluster_target", CLUSTER_1_CONN_ID, 20, cluster1_size, "cluster")
+
+    slack_ops['ws']['remap'] >> reset_cluster_after_ws
 
 
     scaling_global_start = scale_up_cluster_op(dag_manager, "global_start", CLUSTER_1_CONN_ID, 20, cluster1_size, "cluster")

--- a/dags/segmentation_dags.py
+++ b/dags/segmentation_dags.py
@@ -688,12 +688,6 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
         wait["pp"] >> evaluation_task
 
 
-    if min(high_mip, top_mip) - batch_mip > 2:
-        for stage in ["ws", "agg", "cs"]:
-            dsize = len(generate_chunks[stage][batch_mip+2])*2
-            scaling_ops[stage]["extra_down"] = scale_down_cluster_op(dag[stage], stage, CLUSTER_1_CONN_ID, dsize, "cluster")
-            scaling_ops[stage]["extra_down"].set_upstream(slack_ops[stage][batch_mip+1])
-
     if top_mip >= high_mip:
         for stage in ["ws", "agg", "cs"]:
             scaling_ops[stage]["down"] = scale_down_cluster_op(dag[stage], stage, CLUSTER_1_CONN_ID, 0, "cluster")

--- a/slackbot/airflow_api.py
+++ b/slackbot/airflow_api.py
@@ -4,7 +4,7 @@ import functools
 import concurrent.futures
 
 from airflow import settings
-from airflow.models import DagBag, Variable, Connection
+from airflow.models import DagBag, DagModel, Variable, Connection
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.api.common.mark_tasks import set_dag_run_state_to_success
 from airflow.api.common.trigger_dag import trigger_dag
@@ -132,3 +132,13 @@ def __latest_dagrun_state(dag_id):
 
 def latest_dagrun_state(dag_id):
     return run_in_executor(__latest_dagrun_state, dag_id)
+
+def set_is_paused(dag_id, is_paused):
+    dag = DagModel.get_dagmodel(dag_id)
+
+    if not dag:
+        return False
+
+    dag.set_is_paused(is_paused=is_paused)
+
+    return True

--- a/slackbot/heartbeat_commands.py
+++ b/slackbot/heartbeat_commands.py
@@ -1,0 +1,18 @@
+from seuronbot import SeuronBot
+from bot_utils import replyto, extract_command, clear_queues
+from airflow_api import set_is_paused
+
+
+@SeuronBot.on_message(["enable heartbeat check", "disable heartbeat check"],
+                      description="Enable/disable heartbeat check, workers not sending heartbeats will be shutdown if heartbeat check is enabled",
+                      exclusive=False,
+                      cancelable=False,
+                      extra_parameters=False)
+def on_heartbeat_check(msg):
+    cmd = extract_command(msg)
+    if cmd.startswith("disable"):
+        set_is_paused("pipeline_heartbeat", True)
+        replyto(msg, "Heartbeat check disabled")
+    else:
+        set_is_paused("pipeline_heartbeat", False)
+        replyto(msg, "Heartbeat check enabled")

--- a/slackbot/slack_bot.py
+++ b/slackbot/slack_bot.py
@@ -27,6 +27,7 @@ import igneous_tasks_commands
 import custom_tasks_commands
 import synaptor_commands
 import pipeline_commands
+import heartbeat_commands
 
 
 def update_ip_address():


### PR DESCRIPTION
The system works as follows:
1. Workers update the heartbeat entries in the redis server, using the hostname as the key and timestamp as the value. This can be done either in the health check scripts of docker images or directly inside the worker process. The database is flushed at the beginning of inference/segmentation run.
2. The heartbeat dag checks the instances the bot manages every 5 minutes, if an instance has not updated its heartbeat timestamp for 5 minutes, the instance will be deleted. If an instance does not have a heartbeat entry, we assume the instance is starting and a entry will be created, so the next time the instance will be checked like other instances. The bot send the list of the delete instances to the alerts channel.
3. The cluster will not be completely shutdown as long as there are tasks waiting in the queue, the cluster dag will create new instances if the instance group has no member. At this moment we keep at least one instance running in each instance group, because there are tasks do not send heartbeat signals (e.g. `compare_segmentation`).
4. There is a enable/disable heartbeat check command to toggle the heartbeat check from the slack interface.