### PR TITLE
ProcessPool based custom worker script

### DIFF
--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -78,11 +78,11 @@ def GenerateWorkers(context, hostname_manager, worker):
         if checkConsecutiveWorkers(concurrencies):
             cmd = " & \n".join([atomic_cmd] + [GenerateCeleryWorkerCommand(docker_image, docker_env, queue=worker['type']+'_'+str(c['layer']), concurrency=c['concurrency']) for c in concurrencies])
     elif worker['type'] == 'igneous':
-        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + PARALLEL_CMD % {'cmd': "python custom/task_execution.py --queue igneous", 'jobs': worker["concurrency"]}
+        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + "python custom/task_execution.py --queue igneous"
     elif worker['type'] == 'custom-cpu':
-        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + PARALLEL_CMD % {'cmd': "custom/worker_cpu.sh", 'jobs': worker["concurrency"]}
+        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + "custom/worker_cpu.sh"
     elif worker['type'] == 'custom-gpu':
-        cmd = GenerateDockerCommand(docker_image, docker_env+['-e CONDA_INSTALL_PYTORCH="true"']) + ' ' + PARALLEL_CMD % {'cmd': "custom/worker_gpu.sh", 'jobs': worker["concurrency"]}
+        cmd = GenerateDockerCommand(docker_image, docker_env+['-e CONDA_INSTALL_PYTORCH="true"']) + ' ' + "custom/worker_gpu.sh"
     elif worker['type'] in SYNAPTOR_TYPES:
         cmd = GenerateCeleryWorkerCommand(docker_image, docker_env+['-p 8793:8793'], queue=worker['type'], concurrency=1)
     else:

--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -78,11 +78,11 @@ def GenerateWorkers(context, hostname_manager, worker):
         if checkConsecutiveWorkers(concurrencies):
             cmd = " & \n".join([atomic_cmd] + [GenerateCeleryWorkerCommand(docker_image, docker_env, queue=worker['type']+'_'+str(c['layer']), concurrency=c['concurrency']) for c in concurrencies])
     elif worker['type'] == 'igneous':
-        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + "python custom/task_execution.py --queue igneous"
+        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + f"python custom/task_execution.py --queue igneous --concurrency {worker['concurrency']}"
     elif worker['type'] == 'custom-cpu':
-        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + "custom/worker_cpu.sh"
+        cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + f"custom/worker_cpu.sh {worker['concurrency']}"
     elif worker['type'] == 'custom-gpu':
-        cmd = GenerateDockerCommand(docker_image, docker_env+['-e CONDA_INSTALL_PYTORCH="true"']) + ' ' + "custom/worker_gpu.sh"
+        cmd = GenerateDockerCommand(docker_image, docker_env+['-e CONDA_INSTALL_PYTORCH="true"']) + ' ' + f"custom/worker_gpu.sh {worker['concurrency']}"
     elif worker['type'] in SYNAPTOR_TYPES:
         cmd = GenerateCeleryWorkerCommand(docker_image, docker_env+['-p 8793:8793'], queue=worker['type'], concurrency=1)
     else:

--- a/custom/task_execution.py
+++ b/custom/task_execution.py
@@ -22,9 +22,11 @@ import custom_worker
 METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/instance/"
 METADATA_HEADERS = {'Metadata-Flavor': 'Google'}
 
+
 def get_hostname():
     data = requests.get(METADATA_URL + 'hostname', headers=METADATA_HEADERS).text
     return data.split(".")[0]
+
 
 @click.command()
 @click.option('--queue', default="",  help='Name of pull queue to use.')
@@ -37,7 +39,7 @@ def command(queue, timeout):
     statsd = StatsClient(host=statsd_host, port=statsd_port)
 
     param = Variable.get("param", deserialize_json=True)
-    cv_secrets_path = os.path.join(os.path.expanduser('~'),".cloudvolume/secrets")
+    cv_secrets_path = os.path.join(os.path.expanduser('~'), ".cloudvolume/secrets")
     if not os.path.exists(cv_secrets_path):
         os.makedirs(cv_secrets_path)
 
@@ -61,6 +63,7 @@ def command(queue, timeout):
     conn.release()
     return
 
+
 def execute(conn, queue_name, qurl):
     print("Pulling from {}".format(qurl))
     queue = conn.SimpleQueue(queue_name)
@@ -76,7 +79,7 @@ def execute(conn, queue_name, qurl):
             if wait_for_task(q_state, ret_queue, err_queue, conn):
                 print("delete task in queue...")
                 message.ack()
-                print('INFO', task , "succesfully executed")
+                print('INFO', task, "succesfully executed")
             else:
                 break
         except SimpleQueue.Empty:
@@ -88,9 +91,9 @@ def execute(conn, queue_name, qurl):
             print('bye bye')
             break
         except Exception as e:
-            print('ERROR', task, "raised {}\n {}".format(e , traceback.format_exc()))
+            print('ERROR', task, "raised {}\n {}".format(e, traceback.format_exc()))
             conn.release()
-            raise #this will restart the container in kubernetes
+            raise  # this will restart the container in kubernetes
 
 
 def handle_task(q_task, q_state, statsd):

--- a/custom/task_execution.py
+++ b/custom/task_execution.py
@@ -57,11 +57,11 @@ def command(queue, timeout):
     worker = threading.Thread(target=handle_task, args=(q_task, q_state, statsd))
     worker.daemon = True
     worker.start()
-    execute(conn, queue, qurl, timeout)
+    execute(conn, queue, qurl)
     conn.release()
     return
 
-def execute(conn, queue_name, qurl, timeout):
+def execute(conn, queue_name, qurl):
     print("Pulling from {}".format(qurl))
     queue = conn.SimpleQueue(queue_name)
     ret_queue = conn.SimpleQueue(queue_name+"_ret")

--- a/custom/task_execution.py
+++ b/custom/task_execution.py
@@ -3,14 +3,13 @@ from airflow.configuration import conf
 import os
 import time
 import traceback
-import threading
-import queue
 import socket
 import json
 import base64
 import requests
 from datetime import datetime
 import redis
+from concurrent.futures import ProcessPoolExecutor
 
 import click
 from kombu import Connection
@@ -56,32 +55,34 @@ def command(queue, timeout):
         pass
 
     conn = Connection(qurl, heartbeat=timeout)
-    worker = threading.Thread(target=handle_task, args=(q_task, q_state, statsd))
-    worker.daemon = True
-    worker.start()
-    execute(conn, queue, qurl)
+    execute(conn, queue, qurl, statsd)
     conn.release()
     return
 
 
-def execute(conn, queue_name, qurl):
+def execute(conn, queue_name, qurl, statsd):
     print("Pulling from {}".format(qurl))
     queue = conn.SimpleQueue(queue_name)
     ret_queue = conn.SimpleQueue(queue_name+"_ret")
     err_queue = conn.SimpleQueue(queue_name+"_err")
+    executor = ProcessPoolExecutor()
+    futures = []
 
     while True:
         task = 'unknown'
         try:
             message = queue.get_nowait()
             print("put message into queue: {}".format(message.payload))
-            q_task.put(message.payload)
-            if wait_for_task(q_state, ret_queue, err_queue, conn):
+            futures.append(executor.submit(handle_task, message.payload, statsd))
+            if wait_for_task(futures, ret_queue, err_queue, conn):
                 print("delete task in queue...")
                 message.ack()
                 print('INFO', task, "succesfully executed")
             else:
                 break
+            for f in futures[:]:
+                if f.done():
+                    futures.remove(f)
         except SimpleQueue.Empty:
             time.sleep(10)
             print("heart beat")
@@ -90,94 +91,87 @@ def execute(conn, queue_name, qurl):
         except Exception as e:
             print('ERROR', task, "raised {}\n {}".format(e, traceback.format_exc()))
             conn.release()
+            executor.shutdown()
             raise  # this will restart the container in kubernetes
 
-
-def handle_task(q_task, q_state, statsd):
-    while True:
-        if q_task.qsize() == 0:
-            time.sleep(1)
-            continue
-        if q_task.qsize() > 0:
-            msg = q_task.get()
-            print("run task: {}".format(msg))
-            statsd_task_key = msg['metadata'].get('statsd_task_key', 'task')
-            try:
-                with statsd.timer(f'{statsd_task_key}.duration'):
-                    val = custom_worker.process_task(msg['task'])
-            except BaseException as e:
-                val = traceback.format_exc()
-                ret = {
-                    'msg': "error",
-                    'ret': base64.b64encode(val.encode("UTF-8")).decode("UTF-8")
-                }
-                q_state.put(ret)
-                return
-
-            if val:
-                ret = {
-                    'msg': "done",
-                    'ret': val
-                }
-                q_state.put(ret)
-            else:
-                q_state.put("done")
+    executor.shutdown()
 
 
-def wait_for_task(q_state, ret_queue, err_queue, conn):
+def handle_task(msg, statsd):
+    print("run task: {}".format(msg))
+    statsd_task_key = msg['metadata'].get('statsd_task_key', 'task')
+    try:
+        with statsd.timer(f'{statsd_task_key}.duration'):
+            val = custom_worker.process_task(msg['task'])
+    except BaseException:
+        val = traceback.format_exc()
+        ret = {
+            'msg': "error",
+            'ret': base64.b64encode(val.encode("UTF-8")).decode("UTF-8")
+        }
+        return ret
+
+    if val:
+        ret = {
+            'msg': "done",
+            'ret': val
+        }
+        return ret
+    else:
+        return "done"
+
+
+def wait_for_task(futures, ret_queue, err_queue, conn):
     idle_count = 0
     while True:
-        if q_state.qsize() > 0:
-            msg = q_state.get()
-            while q_state.qsize() > 0:
-                msg = q_state.get()
-            print(msg)
-            if msg == "done":
-                print("task done")
-                return True
-            elif isinstance(msg, dict):
-                if msg.get('msg', None) == "done":
-                    if msg.get('ret', None):
-                        try:
-                            ret_queue.put(json.dumps(msg['ret']))
-                        except:
-                            err_queue.put("Cannot jsonify the result from the worker")
+        for f in futures:
+            if f.done():
+                msg = f.result()
+                print(msg)
+                if msg == "done":
                     print("task done")
                     return True
-                elif msg.get('msg', None) == "error":
-                    if msg.get('ret', None):
-                        err_queue.put(json.dumps(msg['ret']))
-                    print("task error")
-                    time.sleep(30)
-                    return False
+                elif isinstance(msg, dict):
+                    if msg.get('msg', None) == "done":
+                        if msg.get('ret', None):
+                            try:
+                                ret_queue.put(json.dumps(msg['ret']))
+                            except:
+                                err_queue.put("Cannot jsonify the result from the worker")
+                        print("task done")
+                        return True
+                    elif msg.get('msg', None) == "error":
+                        if msg.get('ret', None):
+                            err_queue.put(json.dumps(msg['ret']))
+                        print("task error")
+                        time.sleep(30)
+                        return False
+                    else:
+                        print("message unknown: {}".format(msg))
+                        return False
                 else:
                     print("message unknown: {}".format(msg))
                     return False
-            else:
-                print("message unknown: {}".format(msg))
-                return False
-        else: #busy
-            redis_conn.set(hostname, datetime.now().timestamp())
-            cpu_usage = psutil.Process().cpu_percent(interval=1)
-            if cpu_usage < 5:
-                print("task stalled: {}".format(cpu_usage))
-                idle_count += 1
-            else:
-                print("task busy: {}".format(cpu_usage))
-                idle_count = 0
 
-            if idle_count > 6:
-                return False
+        redis_conn.set(hostname, datetime.now().timestamp())
+        cpu_usage = psutil.Process().cpu_percent(interval=1)
+        if cpu_usage < 5:
+            print("task stalled: {}".format(cpu_usage))
+            idle_count += 1
+        else:
+            print("task busy: {}".format(cpu_usage))
+            idle_count = 0
 
-            try:
-                conn.drain_events(timeout=10)
-            except socket.timeout:
-                conn.heartbeat_check()
+        if idle_count > 6:
+            return False
+
+        try:
+            conn.drain_events(timeout=10)
+        except socket.timeout:
+            conn.heartbeat_check()
 
 
 if __name__ == '__main__':
     redis_conn = redis.Redis(os.environ["REDIS_SERVER"])
     hostname = get_hostname()
-    q_state = queue.Queue()
-    q_task = queue.Queue()
     command()

--- a/custom/task_execution.py
+++ b/custom/task_execution.py
@@ -51,7 +51,7 @@ def command(queue, timeout):
 
     try:
         timeout = custom_worker.task_timeout
-    except:
+    except AttributeError:
         pass
 
     conn = Connection(qurl, heartbeat=timeout)
@@ -136,7 +136,7 @@ def wait_for_task(futures, ret_queue, err_queue, conn):
                         if msg.get('ret', None):
                             try:
                                 ret_queue.put(json.dumps(msg['ret']))
-                            except:
+                            except TypeError:
                                 err_queue.put("Cannot jsonify the result from the worker")
                         print("task done")
                         return True

--- a/custom/task_execution.py
+++ b/custom/task_execution.py
@@ -87,9 +87,6 @@ def execute(conn, queue_name, qurl):
             print("heart beat")
             conn.heartbeat_check()
             continue
-        except KeyboardInterrupt:
-            print('bye bye')
-            break
         except Exception as e:
             print('ERROR', task, "raised {}\n {}".format(e, traceback.format_exc()))
             conn.release()

--- a/custom/task_execution.py
+++ b/custom/task_execution.py
@@ -27,10 +27,9 @@ def get_hostname():
     return data.split(".")[0]
 
 @click.command()
-@click.option('--tag', default='',  help='kind of task to execute')
 @click.option('--queue', default="",  help='Name of pull queue to use.')
 @click.option('--timeout', default=60,  help='SQS Queue URL if using SQS')
-def command(tag, queue, timeout):
+def command(queue, timeout):
     qurl = conf.get('celery', 'broker_url')
     statsd_host = conf.get('metrics', 'statsd_host')
     statsd_port = conf.get('metrics', 'statsd_port')
@@ -58,11 +57,11 @@ def command(tag, queue, timeout):
     worker = threading.Thread(target=handle_task, args=(q_task, q_state, statsd))
     worker.daemon = True
     worker.start()
-    execute(conn, tag, queue, qurl, timeout)
+    execute(conn, queue, qurl, timeout)
     conn.release()
     return
 
-def execute(conn, tag, queue_name, qurl, timeout):
+def execute(conn, queue_name, qurl, timeout):
     print("Pulling from {}".format(qurl))
     queue = conn.SimpleQueue(queue_name)
     ret_queue = conn.SimpleQueue(queue_name+"_ret")

--- a/custom/worker_cpu.sh
+++ b/custom/worker_cpu.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python custom/download_script.py
-python custom/task_execution.py --queue "custom-cpu"
+python custom/task_execution.py --queue "custom-cpu" --concurrency "$1"

--- a/custom/worker_gpu.sh
+++ b/custom/worker_gpu.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 python custom/download_script.py
-python custom/task_execution.py --queue "custom-gpu"
+python custom/task_execution.py --queue "custom-gpu" --concurrency "$1"


### PR DESCRIPTION
The old custom scripts only launch one worker per script and the multiprocessing is archived by running multiple scripts using parallel, each worker maintain its own connection to the database and the task queue, which may overwhelm the server when there are too many workers. Use processpool we only need to create connections for each instances, and the tasks are dispatched to different processes internally. This should significantly reduce the pressure of the manager node.