### PR TITLE
Support huge pages

### DIFF
--- a/cloud/google/cloud-deployment.yaml
+++ b/cloud/google/cloud-deployment.yaml
@@ -56,12 +56,14 @@ resources:
               subnetwork: us-east1
               machineType: e2-standard-32
               preemptible: True
+              reserveHugePages: True
               sizeLimit: 100
             - type: composite
               zone: us-east1-c
               subnetwork: us-east1
               machineType: e2-standard-32
               preemptible: False
+              reserveHugePages: True
               workerConcurrencies:
                 - layer: 5
                   concurrency: 4

--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -88,7 +88,9 @@ def GenerateWorkers(context, hostname_manager, worker):
     else:
         raise ValueError(f"unknown worker type: {worker['type']}")
 
-    startup_script = GenerateWorkerStartupScript(context, env_variables, oom_canary_cmd + "& \n" + cmd, (worker['type'] in GPU_TYPES and worker['gpuWorkerAcceleratorType']))
+    use_gpu = worker['type'] in GPU_TYPES and worker['gpuWorkerAcceleratorType']
+
+    startup_script = GenerateWorkerStartupScript(context, env_variables, oom_canary_cmd + "& \n" + cmd, use_gpu=use_gpu)
 
     instance_template = {
         'zone': worker['zone'],

--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -22,7 +22,7 @@ def GenerateEnvironVar(context, env_variables):
     return "\n".join([export_variables, save_variables])
 
 
-def GenerateWorkerStartupScript(context, env_variables, cmd, use_gpu=False):
+def GenerateWorkerStartupScript(context, env_variables, cmd, use_gpu=False, use_hugepages=False):
     startup_script = f'''
 #!/bin/bash
 set -e
@@ -32,6 +32,9 @@ chmod 777 /var/log/airflow/logs
 DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
 {INSTALL_DOCKER_CMD}
 '''
+
+    if use_hugepages:
+        startup_script += "echo $(free -g|grep Mem|awk '{print int($2/2)}') > /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages"
 
     if use_gpu:
         startup_script += INSTALL_NVIDIA_DOCKER_CMD
@@ -89,8 +92,9 @@ def GenerateWorkers(context, hostname_manager, worker):
         raise ValueError(f"unknown worker type: {worker['type']}")
 
     use_gpu = worker['type'] in GPU_TYPES and worker['gpuWorkerAcceleratorType']
+    use_hugepages = worker.get('reserveHugePages', False)
 
-    startup_script = GenerateWorkerStartupScript(context, env_variables, oom_canary_cmd + "& \n" + cmd, use_gpu=use_gpu)
+    startup_script = GenerateWorkerStartupScript(context, env_variables, oom_canary_cmd + "& \n" + cmd, use_gpu=use_gpu, use_hugepages=use_hugepages)
 
     instance_template = {
         'zone': worker['zone'],

--- a/plugins/custom/docker_custom.py
+++ b/plugins/custom/docker_custom.py
@@ -246,6 +246,7 @@ class DockerConfigurableOperator(DockerOperator):
                 'mounts': self.mounts,
                 'cpu_shares': cpu_shares,
                 'mem_limit': self.mem_limit,
+                'cap_add': ["IPC_LOCK", "SYS_NICE"],
                 'network_mode': self.network_mode
             }
             host_args.update(self.host_args)


### PR DESCRIPTION
Add an deployment option to reserve 50% of total memory as hugepages during booting time. Also adjust the docker parameters so we can bind memory to cpu inside a container.