### PR TITLE
Replace preemptible with spot

### DIFF
--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -96,6 +96,8 @@ def GenerateWorkers(context, hostname_manager, worker):
 
     startup_script = GenerateWorkerStartupScript(context, env_variables, oom_canary_cmd + "& \n" + cmd, use_gpu=use_gpu, use_hugepages=use_hugepages)
 
+    provisioning_model = 'SPOT' if worker.get('preemptible', False) else 'STANDARD'
+
     instance_template = {
         'zone': worker['zone'],
         'machineType': worker['machineType'],
@@ -111,7 +113,7 @@ def GenerateWorkers(context, hostname_manager, worker):
             'deployment': context.env['deployment'],
         },
         'scheduling': {
-            'preemptible': worker['preemptible'],
+            'provisioningModel': provisioning_model,
         },
         'metadata': {
             'items': [{


### PR DESCRIPTION
Google deprecated preemptible instances and recommend using spot instances, they should be almost identical in practise, spot instances can run more than 24 hours theoretically.