### PR TITLE
vendor flag

### DIFF
--- a/cloud/google/manager.py
+++ b/cloud/google/manager.py
@@ -4,6 +4,7 @@ from common import INSTALL_DOCKER_CMD, INSTALL_NVIDIA_DOCKER_CMD, CELERY_CMD, PA
 
 def GenerateEnvironVar(context, hostname_manager):
     env_variables = {
+        'VENDOR': 'Google',
         'SLACK_TOKEN': context.properties['slack']['botToken'],
         'SLACK_NOTIFICATION_CHANNEL': context.properties['slack']['notificationChannel'],
         'DEPLOYMENT': context.env['deployment'],

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -5,6 +5,7 @@ x-airflow-common:
     restart: always
     environment:
         &airflow-common-env
+        VENDOR:
         AIRFLOW__CORE__FERNET_KEY:
         AIRFLOW__DATABASE__SQL_ALCHEMY_CONN:
         AIRFLOW__CELERY__BROKER_URL:

--- a/pipeline/init_pipeline.py
+++ b/pipeline/init_pipeline.py
@@ -47,6 +47,7 @@ target_sizes = {
 Variable.setdefault("cluster_target_size", target_sizes, deserialize_json=True)
 Variable.setdefault("param", param_default, deserialize_json=True)
 Variable.setdefault("inference_param", inference_param_default, deserialize_json=True)
+Variable.setdefault("vendor", os.environ.get("VENDOR", "Google"))
 
 db_utils.merge_conn(
         models.Connection(


### PR DESCRIPTION
Introduce a vendor variable to indicate the platform seuron is running. In the future we will use it to adjust dag/bot/cluster behaviors