### PR TITLE
Purge a rabbitmq queue by deleting and recreating it

### DIFF
--- a/common/kombu_helper.py
+++ b/common/kombu_helper.py
@@ -37,21 +37,8 @@ def put_message(broker_url, queue, msg):
 # Can't use the variable name "conn" as an argument bc it's reserved by airflow
 def drain_messages(broker_url, queue):
     with Connection(broker_url) as conn:
+        channel = conn.channel()
+        ret = channel.queue_delete(queue)
+        print(f"deleted {ret} messages")
         simple_queue = conn.SimpleQueue(queue)
-        while True:
-            try:
-                message = simple_queue.get_nowait()
-            except SimpleQueue.Empty:
-                status = check_queue(queue)
-                if "messages" not in status:
-                    sleep(30)
-                    continue
-                elif status["messages"] > 0:
-                    print(f'still {status["messages"]} messages left in {queue}, sleep for 30s')
-                    sleep(30)
-                    continue
-                else:
-                    break
-            #print(f'message: {message.payload}')
-            message.ack()
-        simple_queue.close()
+        print(f"remaining {simple_queue.qsize()} messages")

--- a/slackbot/cancel_run_commands.py
+++ b/slackbot/cancel_run_commands.py
@@ -44,11 +44,11 @@ def cancel_run(msg):
 
     replyto(msg, "Marking all DAG states to success...")
     mark_dags_success()
-    time.sleep(10)
+    time.sleep(60)
 
     #try again because some tasks might already been scheduled
     mark_dags_success()
-    time.sleep(10)
+    time.sleep(60)
 
     replyto(msg, "Draining tasks from the queues...")
     drain_messages(broker_url, "igneous")


### PR DESCRIPTION
This seems to be faster and more reliable than the old draining message approach, we no longer need to wait for unacked messages to reappear. Changes in the check_queue and cancel_run calls need to be adjusted after this change.