### PR TITLE
Request gpus in docker and remove nvidia-container-runtime dependency

### DIFF
--- a/cloud/google/common.py
+++ b/cloud/google/common.py
@@ -21,18 +21,7 @@ curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | apt-key add -
 curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list
 add-apt-repository -y ppa:graphics-drivers/ppa
 apt-get update -y
-DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install nvidia-headless-515 nvidia-utils-515 nvidia-container-toolkit nvidia-container-runtime
-cat << EOF > /etc/docker/daemon.json
-{
-  "default-runtime": "nvidia",
-  "runtimes": {
-    "nvidia": {
-      "path": "nvidia-container-runtime",
-      "runtimeArgs": []
-    }
-  }
-}
-EOF
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install nvidia-headless-515 nvidia-utils-515 nvidia-container-toolkit
 systemctl restart docker
 '''
 

--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -85,7 +85,7 @@ def GenerateWorkers(context, hostname_manager, worker):
     elif worker['type'] == 'custom-cpu':
         cmd = GenerateDockerCommand(docker_image, docker_env) + ' ' + f"custom/worker_cpu.sh {worker['concurrency']} >& /dev/null"
     elif worker['type'] == 'custom-gpu':
-        cmd = GenerateDockerCommand(docker_image, docker_env+['-e CONDA_INSTALL_PYTORCH="true"']) + ' ' + f"custom/worker_gpu.sh {worker['concurrency']} >& /dev/null"
+        cmd = GenerateDockerCommand(docker_image, docker_env + ['--gpus all'] + ['-e CONDA_INSTALL_PYTORCH="true"']) + ' ' + f"custom/worker_gpu.sh {worker['concurrency']} >& /dev/null"
     elif worker['type'] in SYNAPTOR_TYPES:
         cmd = GenerateCeleryWorkerCommand(docker_image, docker_env+['-p 8793:8793'], queue=worker['type'], concurrency=1)
     else:

--- a/dags/chunkflow_dag.py
+++ b/dags/chunkflow_dag.py
@@ -378,6 +378,7 @@ def inference_op(dag, param, queue, wid):
         mount_point=param.get("MOUNT_PATH", default_mount_path),
         task_id='worker_{}'.format(wid),
         command=cmdlist,
+        use_gpus=True,
         force_pull=True,
         image=param["CHUNKFLOW_IMAGE"],
         priority_weight=1,

--- a/dags/synaptor_dags.py
+++ b/dags/synaptor_dags.py
@@ -52,6 +52,7 @@ manager_op(dag_sanity, "sanity_check", image=SYNAPTOR_IMAGE)
 class Task:
     name: str
     cluster_key: str
+    use_gpus: bool
 
 
 class CPUTask(Task):
@@ -59,6 +60,7 @@ class CPUTask(Task):
     def __init__(self, name):
         self.name = name
         self.cluster_key = "synaptor-cpu"
+        self.use_gpus = False
 
 
 class GPUTask(Task):
@@ -66,6 +68,7 @@ class GPUTask(Task):
     def __init__(self, name):
         self.name = name
         self.cluster_key = "synaptor-gpu"
+        self.use_gpus = True
 
 
 class GraphTask(Task):
@@ -73,6 +76,7 @@ class GraphTask(Task):
     def __init__(self, name):
         self.name = name
         self.cluster_key = "synaptor-seggraph"
+        self.use_gpus = False
 
 
 def fill_dag(dag: DAG, tasklist: list[Task], collect_metrics: bool = True) -> DAG:
@@ -146,6 +150,7 @@ def change_cluster_if_required(
             image=SYNAPTOR_IMAGE,
             op_queue_name=next_task.cluster_key,
             tag=new_tag,
+            use_gpus=next_task.use_gpus
         )
         for i in range(cluster_size)
     ]

--- a/dags/synaptor_ops.py
+++ b/dags/synaptor_ops.py
@@ -257,6 +257,7 @@ def synaptor_op(
     op_queue_name: Optional[str] = "synaptor-cpu",
     task_queue_name: Optional[str] = TASK_QUEUE_NAME,
     tag: Optional[str] = None,
+    use_gpus: Optional[bool] = False,
     image: str = default_synaptor_image,
 ) -> BaseOperator:
     """Runs a synaptor worker until it receives a self-destruct task."""
@@ -282,7 +283,7 @@ def synaptor_op(
         mount_point=MOUNT_POINT,
         task_id=task_id,
         command=command,
-        use_gpus=True,
+        use_gpus=use_gpus,
         force_pull=True,
         image=image,
         priority_weight=100_000,

--- a/dags/synaptor_ops.py
+++ b/dags/synaptor_ops.py
@@ -282,6 +282,7 @@ def synaptor_op(
         mount_point=MOUNT_POINT,
         task_id=task_id,
         command=command,
+        use_gpus=True,
         force_pull=True,
         image=image,
         priority_weight=100_000,

--- a/dags/worker_op.py
+++ b/dags/worker_op.py
@@ -7,6 +7,7 @@ def worker_op(**kwargs):
         mount_point=kwargs.get("mount_point", None),
         task_id=kwargs["task_id"],
         command=kwargs["command"],
+        use_gpus=kwargs.get("use_gpus", False),
         xcom_all=kwargs.get('xcom_all', False),
         force_pull=kwargs.get("force_pull", False),
         default_args=default_args,


### PR DESCRIPTION
@nkemnitz told me docker already integrated nvidia gpu support, as long as we explicitly request gpus docker will setup the environment without nvidia-container-runtime.
@nicholasturner1, I made changes to the synaptor operator but did not test it. I do not think it will cause an error to request gpus on a cpu only machine, I have not verified the guess.