### PR TITLE
feat: common nglinks

### DIFF
--- a/common/nglinks.py
+++ b/common/nglinks.py
@@ -1,0 +1,117 @@
+"""Neuroglancer link functions."""
+import json
+import urllib
+from typing import Optional, Union
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
+
+
+class LayerType(Enum):
+    Image = "image"
+    Segmentation = "segmentation"
+
+
+@dataclass
+class Layer:
+    name: str
+    cloudpath: str
+    type: LayerType
+
+
+class ImageLayer(Layer):
+
+    def __init__(self, name: str, cloudpath: str):
+        self.name = name
+        self.cloudpath = cloudpath
+        self.type = LayerType.Image
+
+
+class SegLayer(Layer):
+
+    def __init__(self, name: str, cloudpath: str):
+        self.name = name
+        self.cloudpath = cloudpath
+        self.type = LayerType.Segmentation
+
+
+def generate_ng_payload(
+    layers: list[Layer], center: Optional[tuple[int, int, int]] = None
+) -> dict:
+    """Makes neuroglancer link payloads from mappings between layer names and paths.
+
+    Sets the viewer resolution equal to the first layer's first resolution.
+    """
+    assert len(layers) > 0, "empty layer paths"
+
+    # uses the first resolution and center (through its bounds)
+    base_resolution, base_bounds = layer_resolution_and_bounds(layers[0])
+
+    ngl_layers = OrderedDict()
+    for layer in layers:
+        ngl_layers[layer.name] = {
+            "source": default_to_precomputed_path(layer),
+            "type": layer.type.value,
+        }
+
+    navigation = {"pose": {"position": {"voxelSize": base_resolution}}, "zoomFactor": 4}
+
+    if center is not None:
+        navigation["pose"]["position"]["voxelCoordinates"] = center
+    else:
+        # default to the center of the default_bounds
+        navigation["pose"]["position"]["voxelCoordinates"] = tuple(
+            map(int, (base_bounds.minpt + base_bounds.maxpt) // 2)
+        )
+
+    payload = OrderedDict(
+        [
+            ("layers", ngl_layers),
+            ("navigation", navigation),
+            ("showSlices", False),
+            ("layout", "xy-3d")
+        ]
+    )
+
+    return payload
+
+
+def generate_link(
+    layers: dict[str, Layer],
+    host: str = "state-share-dot-neuroglancer-dot-seung-lab.appspot.com",
+) -> str:
+    payload = generate_ng_payload(layers)
+
+    return wrap_payload(payload, host)
+
+
+def wrap_payload(
+    payload: Union[OrderedDict, str],
+    host: str = "state-share-dot-neuroglancer-dot-seung-lab.appspot.com",
+    link_text: str = "neuroglancer link"
+) -> str:
+    if isinstance(payload, OrderedDict):
+        payload = urllib.parse.quote(json.dumps(payload))
+
+    return f"<https://{host}/#!{payload}|*{link_text}*>"
+
+
+def default_to_precomputed_path(layer: Layer):
+    return (
+        layer.cloudpath
+        if (
+            layer.cloudpath.startswith("precomputed://")
+            or layer.cloudpath.startswith("graphene://")
+        )
+        else f"precomputed://{layer.cloudpath}"
+    )
+
+
+def layer_resolution_and_bounds(layer_or_path: Union[str, Layer], mip=0):
+    from cloudvolume import CloudVolume
+    path = (
+        layer_or_path.cloudpath if isinstance(layer_or_path, Layer) else layer_or_path
+    )
+    vol = CloudVolume(path, mip=mip)
+
+    return vol.resolution.tolist(), vol.bounds


### PR DESCRIPTION
Making a common interface for specifying neuroglancer links. This refactors the code from chunkflow for generating neuroglancer links with a few extra features:
* supports an arbitrary number of layers specified by a dict
* a separate `generate_payload` function allows the user to customize the payload before generating a link
* allows customizing the link text when using wrap_payload (could also add this as an arg to `generate_link`)

It does not support image shaders yet, but this could be implemented as an add-on to the payload (bullet #2). This technique is used in the next PR to add synapse line annotations when running synapse assignment. This also could be used in generating links for batches of jobs within the slackbot, so I put this module in common. I've experimented with doing this for "easy seg" in the training loop branch.