### PR TITLE
Track GCS api calls

### DIFF
--- a/dags/compute_metrics_dag.py
+++ b/dags/compute_metrics_dag.py
@@ -63,11 +63,18 @@ with DAG("compute_metrics",
         messages = []
         resources = collect_resource_metrics(start_time, end_time)
         for ig in resources:
+            if ig == "GCS":
+                continue
             if resources[ig]:
                 if "gpu_utilization" in resources[ig]:
                     messages += [f"`{ig}`: `{format_uptime(resources[ig]['uptime'])}` (`{resources[ig]['gpu_utilization']:.2f}%` GPU utilization, `{resources[ig]['cpu_utilization']:.2f}%` CPU utilization), `{humanize.naturalsize(resources[ig]['received_bytes'])}` received, `{humanize.naturalsize(resources[ig]['sent_bytes'])}` sent"]
                 else:
                     messages += [f"`{ig}`: `{format_uptime(resources[ig]['uptime'])}` (`{resources[ig]['cpu_utilization']:.2f}%` CPU utilization), `{humanize.naturalsize(resources[ig]['received_bytes'])}` received, `{humanize.naturalsize(resources[ig]['sent_bytes'])}` sent"]
+
+        if resources["GCS"]:
+            for b in resources["GCS"]:
+                api_summary = ",".join([f"`{k}`: {humanize.intword(v)}" for k, v in resources["GCS"][b].items()])
+                messages += [f"GCS api call to bucket `{b}`: {api_summary}"]
 
         if messages:
             slack_message("\n".join([f"*Compute resources used by* `{target_dag_id}` *in {pendulum.period(start_time, end_time).in_words()}*:"] + messages), broadcast=True)

--- a/dags/sanitycheck_dag.py
+++ b/dags/sanitycheck_dag.py
@@ -245,6 +245,8 @@ def check_worker_image_op(dag):
 def print_summary():
     from docker_helper import health_check_info
     from dag_utils import check_manager_node, get_composite_worker_capacities
+    from cloudfiles.paths import extract
+
     param = Variable.get("param", deserialize_json=True)
     data_bbox = param["BBOX"]
 
@@ -293,6 +295,15 @@ def print_summary():
             paths[path] = param["{}_PREFIX".format(p)]+param["NAME"]
         else:
             paths[path] = param["{}_PATH".format(p)]
+
+    gcs_buckets = set()
+    for path in list(paths.values()) + [param['AFF_PATH'], param.get("SEM_PATH", None), param.get("GT_PATH", None)]:
+        if path:
+            components = extract(path)
+            if components.protocol == "gs":
+                gcs_buckets.add(components.bucket)
+
+    Variable.set("gcs_buckets", list(gcs_buckets), serialize_json=True)
 
     msg = '''
 :heavy_check_mark: *Sanity Check, everything looks OK*


### PR DESCRIPTION
Track GCS api calls to a list of buckets during segmentation and chunkflow run. The stats may include accesses from other process/clients, have not found a way to tag api calls to specific instances/services. But it should be a fairly good approximation in most cases