### PR TITLE
heartbeat check

### DIFF
--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -41,6 +41,13 @@ def list_managed_instances(instance_group):
 
     return instances
 
+def get_instance_property(instance_group, instance, key):
+    project_id = get_project_id()
+    service = discovery.build("compute", "v1")
+    request = service.instances().get(project=project_id, zone=instance_group['zone'], instance=instance)
+    ret = request.execute()
+    return ret[key]
+
 def delete_instances(ig, instances):
     project_id = get_project_id()
     request_body = {


### PR DESCRIPTION
Currently the heartbeat check is disabled if the instance group is still scaling up, meaning the requested size does not match the actually number of instances in the group. However, The requested size may not be fulfilled for a long time or never can be fulfilled (when the request exceeds the quota). We still want to run heartbeat check to get rid of idle or dead instances. The new code will check the creation timestamp of each idle instance and ignore the heartbeat error if it is created within the last 10 minutes. This also solves another issue of gce: sometime it preempt an instance and put it right back in with the same name. The timestamp check makes sure the instances have enough time to setup itself.