### PR TITLE
Fix post-process-only run

### DIFF
--- a/dags/sanitycheck_dag.py
+++ b/dags/sanitycheck_dag.py
@@ -382,9 +382,10 @@ Fundamental chunk size: {chunk_size}
     if not param.get("SKIP_AGG", False) and "GT_PATH" in param:
         msg += """:vs: Evaluate the output against ground truth `{}`\n""".format(param["GT_PATH"])
 
-    missing_workers = [x for x in range(param.get("HIGH_MIP", 5), top_mip+1) if x not in composite_workers]
-    if missing_workers:
-        msg += f"""*WARNING: No dedicated worker for layer {','.join(str(x) for x in missing_workers)}, the tasks will be done by workers configured for other layers*"""
+    if not (param.get("SKIP_WS", False) and param.get("SKIP_AGG", False)):
+        missing_workers = [x for x in range(param.get("HIGH_MIP", 5), top_mip+1) if x not in composite_workers]
+        if missing_workers:
+            msg += f"""*WARNING: No dedicated worker for layer {','.join(str(x) for x in missing_workers)}, the tasks will be done by workers configured for other layers*"""
 
     slack_message(msg, broadcast=True)
 

--- a/dags/sanitycheck_dag.py
+++ b/dags/sanitycheck_dag.py
@@ -289,8 +289,8 @@ def print_summary():
         ntasks += bchunks
         ntasks *= 2
 
-    if not check_manager_node(bchunks):
-        raise RuntimeError("Not enough resources")
+        if not check_manager_node(bchunks):
+            raise RuntimeError("Not enough resources")
 
     paths = {}
 

--- a/dags/sanitycheck_dag.py
+++ b/dags/sanitycheck_dag.py
@@ -379,7 +379,7 @@ Fundamental chunk size: {chunk_size}
     if param.get("MESH_QUALITY", "NORMAL") == "PERFECT":
         msg += ":exclamation:Meshing without any simplification requires significantly more time and resources!\n"
 
-    if "GT_PATH" in param:
+    if not param.get("SKIP_AGG", False) and "GT_PATH" in param:
         msg += """:vs: Evaluate the output against ground truth `{}`\n""".format(param["GT_PATH"])
 
     missing_workers = [x for x in range(param.get("HIGH_MIP", 5), top_mip+1) if x not in composite_workers]

--- a/dags/segmentation_dags.py
+++ b/dags/segmentation_dags.py
@@ -625,10 +625,12 @@ if "BBOX" in param and "CHUNK_SIZE" in param: #and "AFF_MIP" in param:
 
     slack_ops['ws']['remap'] >> reset_cluster_after_ws
 
-
-    scaling_global_start = scale_up_cluster_op(dag_manager, "global_start", CLUSTER_1_CONN_ID, 20, cluster1_size, "cluster")
-
-    scaling_global_finish = scale_down_cluster_op(dag_manager, "global_finish", CLUSTER_1_CONN_ID, 0, "cluster")
+    if param.get("SKIP_AGG", False) and param.get("SKIP_WS", False):
+        scaling_global_start = placeholder_op(dag_manager, "global_start")
+        scaling_global_finish = placeholder_op(dag_manager, "global_finish")
+    else:
+        scaling_global_start = scale_up_cluster_op(dag_manager, "global_start", CLUSTER_1_CONN_ID, 20, cluster1_size, "cluster")
+        scaling_global_finish = scale_down_cluster_op(dag_manager, "global_finish", CLUSTER_1_CONN_ID, 0, "cluster")
 
     scaling_cs_start = scale_up_cluster_op(dag_cs, "cs_start", CLUSTER_1_CONN_ID, 20, cluster1_size, "cluster")
 


### PR DESCRIPTION
Skip checks and operators for watershed and agglomeration if we only want to run the post-process part.