### PR TITLE
Turn on/off nfs server for standalone igneous tasks

### DIFF
--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -390,8 +390,22 @@ def toggle_nfs_server(on=False):
     deployment = nfs_conn.host
     zone = nfs_conn.login
     nfs_server = f"{deployment}-nfs-server"
-    slack_message(f'*Turning {"on" if on else "off"} the nfs server*')
     if on:
         start_instance(nfs_server, zone)
+        wait_for_instance(nfs_server, zone, "RUNNING")
     else:
         stop_instance(nfs_server, zone)
+        wait_for_instance(nfs_server, zone, "TERMINATED")
+
+    slack_message(f'*Turning {"on" if on else "off"} the nfs server*')
+
+
+def wait_for_instance(instance, zone, target, retries=5):
+    for _ in range(retries):
+        status = get_instance_property(zone, instance, "status")
+        if status == target:
+            return
+        sleep(60)
+
+    slack_message(f'*Timeout while waiting {instance}*')
+    raise RuntimeError(f"Timeout waiting {instance}")

--- a/dags/google_api_helper.py
+++ b/dags/google_api_helper.py
@@ -390,6 +390,7 @@ def toggle_nfs_server(on=False):
     deployment = nfs_conn.host
     zone = nfs_conn.login
     nfs_server = f"{deployment}-nfs-server"
+    slack_message(f'*Turning {"on" if on else "off"} the nfs server*')
     if on:
         start_instance(nfs_server, zone)
     else:

--- a/dags/helper_ops.py
+++ b/dags/helper_ops.py
@@ -211,6 +211,7 @@ def toggle_nfs_server_op(dag, on=False):
             default_args=default_args,
             weight_rule=WeightRule.ABSOLUTE,
             priority_weight=1000,
+            trigger_rule="all_done",
             queue='manager',
             dag=dag
         )

--- a/dags/igneous_dag.py
+++ b/dags/igneous_dag.py
@@ -4,7 +4,7 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.weight_rule import WeightRule
 from datetime import datetime
 from slack_message import task_failure_alert
-from helper_ops import scale_down_cluster_op, collect_metrics_op
+from helper_ops import scale_down_cluster_op, collect_metrics_op, toggle_nfs_server_op
 
 igneous_default_args = {
     'owner': 'seuronbot',
@@ -17,6 +17,8 @@ igneous_default_args = {
 dag_igneous = DAG("igneous", default_args=igneous_default_args, schedule_interval=None, tags=['igneous tasks'])
 scaling_igneous_finish = scale_down_cluster_op(dag_igneous, "igneous_finish", "igneous", 0, "cluster")
 
+start_nfs_server = toggle_nfs_server_op(dag_igneous, on=True)
+stop_nfs_server = toggle_nfs_server_op(dag_igneous, on=False)
 
 submit_igneous_tasks = PythonOperator(
     task_id="submit_igneous_tasks",
@@ -28,7 +30,7 @@ submit_igneous_tasks = PythonOperator(
     dag=dag_igneous
 )
 
-collect_metrics_op(dag_igneous) >> submit_igneous_tasks >> scaling_igneous_finish
+collect_metrics_op(dag_igneous) >> start_nfs_server >> submit_igneous_tasks >> scaling_igneous_finish >> stop_nfs_server
 
 
 dag_custom_cpu = DAG("custom-cpu", default_args=igneous_default_args, schedule_interval=None, tags=['custom tasks'])


### PR DESCRIPTION
When the bot is deployed with a nfs server, the instances for igneous tasks will try to mount the nfs volume before starting the workers. Turn on the nfs server before starting the run and turn it off afterwards. This change slows down the process quite a bit for small or failed runs because we have to wait for the server to start and stop.