### PR TITLE
Serve igneous frag files through http interface

### DIFF
--- a/cloud/google/nfs_server.py
+++ b/cloud/google/nfs_server.py
@@ -77,8 +77,8 @@ shutdown -h now
 
 fi
 
-sysctl -w net.netfilter.nf_conntrack_max=2097152
-echo 524288 > /sys/module/nf_conntrack/parameters/hashsize
+sysctl -w net.netfilter.nf_conntrack_max=$(awk '/MemAvailable/ {{print int($2/16)}}' /proc/meminfo)
+echo $(awk '/MemAvailable/ {{print int($2/64)}}' /proc/meminfo) > /sys/module/nf_conntrack/parameters/hashsize
 mount /dev/sdb /share
 chmod 777 /share
 systemctl restart nfs-kernel-server.service


### PR DESCRIPTION
NFS has huge overhead when reading small pieces of frag files due to caching/prefetching, switch to http interface to alleviate the problem. Uploading is still through nfs