### PR TITLE
Split synaptor queue

### DIFF
--- a/dags/cluster_dag.py
+++ b/dags/cluster_dag.py
@@ -61,6 +61,8 @@ def estimate_optimal_number_of_workers(cluster, cluster_info):
     else:
         if cluster == "gpu":
             num_tasks = check_queue(queue="chunkflow")
+        elif cluster.startswith("synaptor"):
+            num_tasks = check_queue(queue=f"{cluster}-tasks")
         else:
             num_tasks = check_queue(queue=cluster)
         num_workers = estimate_worker_instances(num_tasks, cluster_info)

--- a/dags/synaptor_ops.py
+++ b/dags/synaptor_ops.py
@@ -193,7 +193,7 @@ def drain_op(
     """Drains leftover messages from the RabbitMQ."""
 
     return PythonOperator(
-        task_id="drain_messages",
+        task_id=f"drain_messages_{task_queue_name}",
         python_callable=drain_messages,
         priority_weight=100_000,
         op_args=(airflow_broker_url, task_queue_name),
@@ -317,12 +317,12 @@ def synaptor_op(
     )
 
 
-def wait_op(dag: DAG, taskname: str) -> PythonOperator:
+def wait_op(dag: DAG, taskname: str, task_queue_name: Optional[str] = TASK_QUEUE_NAME) -> PythonOperator:
     """Waits for a task to finish."""
     return PythonOperator(
         task_id=f"wait_for_queue_{taskname}",
         python_callable=check_queue,
-        op_args=(TASK_QUEUE_NAME,),
+        op_args=(task_queue_name,),
         priority_weight=100_000,
         weight_rule=WeightRule.ABSOLUTE,
         on_success_callback=task_done_alert,

--- a/slackbot/cancel_run_commands.py
+++ b/slackbot/cancel_run_commands.py
@@ -64,6 +64,9 @@ def cancel_run(msg):
     drain_messages(broker_url, "custom-gpu")
     drain_messages(broker_url, "chunkflow")
     drain_messages(broker_url, "synaptor")
+    drain_messages(broker_url, "synaptor-cpu-tasks")
+    drain_messages(broker_url, "synaptor-gpu-tasks")
+    drain_messages(broker_url, "synaptor-seggraph-tasks")
     drain_messages(broker_url, "deepem-gpu")
     time.sleep(10)
 


### PR DESCRIPTION
Split synaptor queue into multiple queues, one for each worker groups. This prevent wrong types of workers still other workers' tasks and causing the dag to go out of sync.