### PR TITLE
DDP support for training loop

### DIFF
--- a/cloud/google/workers.py
+++ b/cloud/google/workers.py
@@ -26,6 +26,13 @@ def GenerateWorkerStartupScript(context, hostname_nfs_server, env_variables, cmd
     startup_script = f'''
 #!/bin/bash
 set -e
+
+echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf
+echo "net.ipv6.conf.lo.disable_ipv6 = 1" >> /etc/sysctl.conf
+
+sysctl -p
+
 mount -t tmpfs -o size=80%,noatime tmpfs /tmp
 mkdir -p /var/log/airflow/logs
 chmod 777 /var/log/airflow/logs

--- a/common/docker_helper.py
+++ b/common/docker_helper.py
@@ -13,6 +13,20 @@ def health_check_info(image_name):
     return False
 
 
+def has_custom_entrypoint(image_name):
+    image = pull_image(image_name)
+    try:
+        entrypoint = image.attrs.get("Config", {}).get("Entrypoint", None)
+
+        if entrypoint:
+            return True
+        else:
+            return False
+    except Exception as e:
+        print(f"Error: {e}")
+        return True
+
+
 def pull_image(image_name):
     import docker
     import traceback

--- a/dags/training.py
+++ b/dags/training.py
@@ -30,6 +30,12 @@ if "rdzv_id" not in PARAM:
     PARAM["rdzv_id"] = str(uuid.uuid4())
     Variable.set("training_param", PARAM, serialize_json=True)
 
+if "gpu_ids" not in PARAM:
+    num_gpus = cluster_info[training_cluster][0]['gpuWorkerAcceleratorCount']
+    PARAM["gpu_ids"] = list(range(num_gpus))
+    Variable.set("training_param", PARAM, serialize_json=True)
+
+
 SKIP_EXPORT = PARAM.pop("skip_export", False)
 
 default_args = dict(

--- a/dags/training.py
+++ b/dags/training.py
@@ -78,10 +78,14 @@ def prep_parameters() -> dict:
 
 def make_argstr(param: dict, num_trainers: int, rank: int, rdzv_id: str) -> str:
 
-    launch_command = ["torchrun", f"--nproc_per_node={len(param['gpu_ids'])}",
-                      f"--nnodes={num_trainers}", f"--node_rank={rank}", f"--rdzv_id={rdzv_id}",
-                      "--rdzv_backend=etcd-v2", f"--rdzv_endpoint={os.environ['REDIS_SERVER']}:2379",
-                      "/DeepEM/deepem/train/run.py"]
+    torchrun_launcher =  param.pop("TORCHRUN_LAUNCHER", None)
+    if torchrun_launcher:
+        launch_command = ["torchrun", f"--nproc_per_node={len(param['gpu_ids'])}",
+                          f"--nnodes={num_trainers}", f"--node_rank={rank}", f"--rdzv_id={rdzv_id}",
+                          "--rdzv_backend=etcd-v2", f"--rdzv_endpoint={os.environ['REDIS_SERVER']}:2379",
+                          "/DeepEM/deepem/train/run.py"]
+    else:
+        launch_command = []
 
     def format_arg(item) -> str:
         k, v = item

--- a/dags/training.py
+++ b/dags/training.py
@@ -104,6 +104,7 @@ def training_op(dag: DAG, queue="deepem-gpu") -> Operator:
         dag=dag,
         qos=False,
         shm_size=4 * (2 ** 30),  # 4 GB
+        network_mode="host",
     )
 
 

--- a/dags/worker_op.py
+++ b/dags/worker_op.py
@@ -26,4 +26,5 @@ def worker_op(**kwargs):
         retry_delay=kwargs.get("retry_delay", default_args.get("retry_delay", 60)),
         retry_exponential_backoff=kwargs.get("retry_exponential_backoff", default_args.get("retry_exponential_backoff", False)),
         shm_size=kwargs.get("shm_size", None),
+        network_mode=kwargs.get("network_mode", None),
     )

--- a/deploy/docker-compose-CeleryExecutor.yml
+++ b/deploy/docker-compose-CeleryExecutor.yml
@@ -215,6 +215,18 @@ services:
             <<: *airflow-common-env
         command: python utils/memory_monitor.py amqp://rabbitmq worker-client-queue
 
+    etcd:
+        image: quay.io/coreos/etcd:v3.5.17
+        ports:
+            - "2379:2379/tcp"
+        command: >
+            /usr/local/bin/etcd
+            --data-dir /var/lib/etcd
+            --enable-v2
+            --listen-client-urls http://0.0.0.0:2379
+            --advertise-client-urls http://0.0.0.0:2379
+            --initial-cluster-state new
+
     proxy:
         image: nginx:1.23.0-alpine
         environment:

--- a/pipeline/init_pipeline.py
+++ b/pipeline/init_pipeline.py
@@ -44,6 +44,8 @@ def parse_metadata():
                     worker_setting['workerConcurrencies'] = c['workerConcurrencies']
                 else:
                     worker_setting['concurrency'] = c.get('concurrency', 1)
+                if c['type'] == 'deepem-gpu':
+                    worker_setting['gpuWorkerAcceleratorCount'] = c.get('gpuWorkerAcceleratorCount', 1)
                 instance_groups[c['type']].append(worker_setting)
         elif item["key"] == "easyseg-worker":
             worker = json.loads(item["value"])


### PR DESCRIPTION
Add a new parameter `NUM_TRAINERS` to specify the number of gpu instances. Only works with [DDP](https://github.com/ZettaAI/DeepEM/tree/DDP) branch of DeepEM. `gpu_ids` is important for specifying the number of processes in each instance, but does not actually restrict the gpus used. If its length is larger than the actual number of gpus the training will fail.
`batch_size` and `num_workers` are now batch_size and num_worker per process/gpu. So you need to scale down the numbers from previous training script to match the change.
Not sure the current version is very compatible with spot instance training. Elastic training cannot be all spot instances and we are not using it now, any instance loss will cause the entire training to fail, to resume seems to require a new `rdvz_id` which only happens with a `update parameter` command for now.